### PR TITLE
fix: protect main builds from cancel-in-progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   SKIP_DEPS: 1
@@ -145,6 +145,7 @@ jobs:
     needs: changes
     if: (needs.changes.outputs.code == 'true' && github.event_name == 'pull_request') || github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - run: bash scripts/ci/install-deps.sh lcov bc
@@ -173,6 +174,7 @@ jobs:
     needs: changes
     if: (needs.changes.outputs.code == 'true' && github.event_name == 'pull_request') || github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Build and test with ASan/UBSan


### PR DESCRIPTION
## Summary

- `cancel-in-progress` now only applies to PR branches, not main — prevents main builds from being cancelled by concurrent runs
- Added `timeout-minutes: 10` to `sanitizers` and `test-coverage` jobs to prevent runaway builds

## Context

The latest main build (run 24846355973) had both `sanitizers` and `test-coverage` jobs cancelled simultaneously. Root cause unclear (no second push, no manual cancel), but the `cancel-in-progress: true` setting made main vulnerable to cancellation.

## Verified

- YAML lint passes
- All 14 pre-push checks pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline reliability by setting execution time limits for test and validation jobs.
  * Optimized workflow concurrency handling to preserve build continuity on the main production branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->