### PR TITLE
feat: stateful sync mode with session, capabilities, and sandbox (ADR-056)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
     if: (needs.changes.outputs.code == 'true' && github.event_name == 'pull_request') || github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    environment: workflow
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - run: bash scripts/ci/install-deps.sh lcov bc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
       - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           files: coverage.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   sanitizers:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 This codebase is kept accessible for C++ newcomers:
 
 - Write simple C++ — no template magic, no operator overloading, no unnecessary abstractions
+- Write booleans in positive, so allow, (not supress or deny), so you get !allowed instead of double negation.
 - Comments explain *why*, not *what* — we enforce a **minimum 20% comment ratio** in all code and scripts (`make comment-ratio`)
 - Test names read as documentation: `TEST_CASE("config: env vars override defaults")`
 - Prefer `std::string` over `const char*`, `std::vector` over raw arrays

--- a/INDEX.md
+++ b/INDEX.md
@@ -47,6 +47,8 @@ Auto-generated overview of all files in this repo.
 - [`docs/adr/adr-053-cpp-static-analysis.md`](docs/adr/adr-053-cpp-static-analysis.md) — ADR-053: C++ Static Analysis Coverage
 - [`docs/adr/adr-054-gemma4-31b-second-chance.md`](docs/adr/adr-054-gemma4-31b-second-chance.md) — ADR-054: gemma4:31b — Second Chance with Tweaks
 - [`docs/adr/adr-055-layered-test-strategy.md`](docs/adr/adr-055-layered-test-strategy.md) — ADR-055: Layered Test Strategy — From Unit Tests to Fuzzing
+- [`docs/adr/adr-056-session-sync.md`](docs/adr/adr-056-session-sync.md) — ADR-056: Stateful Sync Mode via `--session`
+- [`docs/adr/adr-057-web-search-integration.md`](docs/adr/adr-057-web-search-integration.md) — ADR-057: Web Search Integration via Tool Annotations
 - [`docs/adr/README.md`](docs/adr/README.md) — Architecture Decision Records
 - [`docs/architecture-v2.md`](docs/architecture-v2.md) — Architecture V2: Multi-Model Provider System
 - [`docs/architecture.md`](docs/architecture.md) — Technical architecture overview — how llama-cli works internally
@@ -96,6 +98,7 @@ Auto-generated overview of all files in this repo.
 - [`docs/code-rabbit.md`](docs/code-rabbit.md) — > ## Documentation Index
 - [`docs/credits-in-ai.md`](docs/credits-in-ai.md) — Using AI Efficiently
 - [`docs/design/tgpt-integration.md`](docs/design/tgpt-integration.md) — Design: tgpt Provider Integration & /model Command
+- [`docs/feature-coverage.md`](docs/feature-coverage.md) — Feature Coverage Matrix
 - [`docs/full-test-script.md`](docs/full-test-script.md) — Manual Test Script
 - [`docs/gh-manual.md`](docs/gh-manual.md) — GitHub CLI Manual (gh)
 - [`docs/github-integration.md`](docs/github-integration.md) — Work seamlessly with GitHub from the command line.
@@ -219,4 +222,4 @@ Auto-generated overview of all files in this repo.
 - [`src/tui/markdown_it.cpp`](src/tui/markdown_it.cpp) — /**
 - [`src/tui/tui.h`](src/tui/tui.h) — /**
 
-_216 files indexed._
+_219 files indexed._

--- a/docs/adr/adr-056-session-sync.md
+++ b/docs/adr/adr-056-session-sync.md
@@ -1,0 +1,187 @@
+# ADR-056: Stateful Sync Mode via `--session`
+
+*Status*: Accepted · *Date*: 2026-04-24 · *Context*: External tools (Kiro CLI, scripts, CI pipelines) use sync mode for one-shot queries but cannot hold multi-turn conversations because sync mode discards history after each call. This blocks delegation patterns where an orchestrator needs follow-up capability.
+
+## Problem
+
+```bash
+# First question works fine
+./llama-cli "what is the eisenhower matrix?"
+
+# Follow-up has no context — LLM doesn't know what "it" refers to
+./llama-cli "give me examples for each quadrant"
+```
+
+Sync mode is stateless by design (ADR-005). Each invocation builds a fresh `vector<Message>`, sends it to Ollama, and exits. There is no mechanism to carry conversation history across invocations.
+
+## Decision
+
+Add a `--session PATH` flag that persists conversation history to a JSON file between sync invocations.
+
+### Usage
+
+```bash
+# First call — creates session file, sends system prompt + user message
+./llama-cli --session /tmp/chat.json "what is the eisenhower matrix?"
+
+# Follow-up — loads history from file, appends new message, full context sent
+./llama-cli --session /tmp/chat.json "give me examples for each quadrant"
+
+# Combine with --files for context-aware follow-ups
+./llama-cli --session /tmp/review.json --files src/main.cpp "review this code"
+./llama-cli --session /tmp/review.json "now focus on error handling"
+
+# Inspect the conversation
+cat /tmp/chat.json
+
+# Clean up when done
+rm /tmp/chat.json
+```
+
+### Flow
+
+```mermaid
+flowchart TD
+    A["llama-cli --session path 'prompt'"] --> B{session file exists?}
+    B -->|no| C[create empty history]
+    B -->|yes| D[load history from file]
+    C --> E[add system prompt]
+    E --> F[append user message]
+    D --> F
+    F --> G[send full history to Ollama]
+    G --> H[stream response to stdout]
+    H --> I[append assistant response to history]
+    I --> J[save history to session file]
+```
+
+### Session file format
+
+The file is a JSON array of message objects — the same structure used internally by `ollama_chat()`:
+
+```json
+[
+  {"role":"system","content":"You are llama-cli, a local AI assistant..."},
+  {"role":"user","content":"what is the eisenhower matrix?"},
+  {"role":"assistant","content":"The Eisenhower Matrix helps prioritize..."},
+  {"role":"user","content":"give me examples for each quadrant"},
+  {"role":"assistant","content":"Sure, here are examples..."}
+]
+```
+
+### State diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoFile: first invocation
+    NoFile --> HasHistory: save after response
+    HasHistory --> HasHistory: each follow-up appends 2 messages
+    HasHistory --> [*]: caller deletes file
+```
+
+### Interaction with other flags
+
+| `--session` | `--files` | Stdin | Behavior |
+|-------------|-----------|-------|----------|
+| — | — | prompt | One-shot sync (unchanged) |
+| PATH | — | prompt | Stateful sync: load/save history |
+| PATH | files | prompt | Stateful sync: file context + prompt appended |
+| — | files | prompt | One-shot with file context (unchanged, ADR-030) |
+| PATH | — | — | Error: no prompt provided |
+
+### Sequence: orchestrator using `--session`
+
+```mermaid
+sequenceDiagram
+    participant K as Kiro CLI
+    participant L as llama-cli
+    participant O as Ollama
+    participant F as session.json
+
+    K->>L: --session /tmp/s.json "explain main.cpp"
+    L->>F: file exists? (no)
+    L->>O: [system, user] messages
+    O-->>L: streamed response
+    L->>F: save [system, user, assistant]
+    L-->>K: response on stdout
+
+    K->>L: --session /tmp/s.json "what about error handling?"
+    L->>F: load [system, user, assistant]
+    L->>O: [system, user, assistant, user] messages
+    O-->>L: streamed response
+    L->>F: save [system, user, assistant, user, assistant]
+    L-->>K: response on stdout
+
+    K->>F: rm /tmp/s.json (cleanup)
+```
+
+### Implementation
+
+**config.h** — add field:
+
+```cpp
+std::string session_path;  ///< Session file for multi-turn sync (--session, ADR-056)
+```
+
+**config.cpp** — add to `opts[]` table (reuses existing `match_string_opts` machinery):
+
+```cpp
+{"--session=", nullptr, &Config::session_path},
+```
+
+**main.cpp** — session helpers + sync mode wiring:
+
+```cpp
+// Load: read messages from JSON file (empty vector if file doesn't exist)
+static std::vector<Message> load_session(const std::string& path);
+
+// Save: write messages array to JSON file
+static void save_session(const std::string& path, const std::vector<Message>& msgs);
+
+// In sync mode:
+std::vector<Message> messages = cfg.session_path.empty()
+    ? std::vector<Message>{}
+    : load_session(cfg.session_path);
+
+// System prompt only on first turn (not already in history)
+if (messages.empty() && !cfg.system_prompt.empty()) {
+  messages.push_back({"system", cfg.system_prompt});
+}
+messages.push_back({"user", cfg.prompt});
+
+// ... send to Ollama, get response ...
+
+if (!cfg.session_path.empty()) {
+  messages.push_back({"assistant", response});
+  save_session(cfg.session_path, messages);
+}
+```
+
+### JSON parsing approach
+
+Reuses `json_extract_string()` from `json/json.h` for reading. Serialization uses a minimal `escape_json()` helper in main.cpp — same escape logic as `ollama.cpp` but kept local to avoid coupling.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| Generated session ID | Requires state management, lookup table, cleanup daemon |
+| SQLite database | Overkill for a conversation log |
+| Append-only JSONL | Simpler writes but harder to parse as messages array |
+| Shared memory / socket | Adds IPC complexity, breaks the stateless CLI model |
+| Keep REPL running in background | Needs process management, TTY allocation |
+
+## Why a file path, not a generated ID
+
+- No server component needed — llama-cli stays stateless
+- The caller controls where the file lives and when to delete it
+- Easy to inspect and debug — it's just JSON
+- Multiple parallel sessions are trivial — different file paths
+- Works in CI, scripts, containers — anywhere with a filesystem
+
+## Consequences
+
+- Sync mode gains multi-turn capability with zero architectural change
+- ~70 lines added to main.cpp (helpers + wiring)
+- Session files grow unbounded — caller is responsible for cleanup or rotation
+- No built-in context window management — if history exceeds model context, Ollama truncates
+- Future: could add `--session-clear` to reset, or `--session-last N` to limit history depth

--- a/docs/adr/adr-056-session-sync.md
+++ b/docs/adr/adr-056-session-sync.md
@@ -215,12 +215,13 @@ Capabilities are additive and comma-separated:
 
 The `read` capability allows `<exec>` only for commands whose first word is in this allowlist:
 
-```
+```text
 cat ls find grep head tail wc stat tree du df
 file diff sort uniq awk sed less more realpath dirname basename
 ```
 
 Safety rules:
+
 - Each pipe segment is checked independently (`cat foo | grep bar` → both OK)
 - Redirects (`>`, `>>`) are always blocked in read mode
 - Commands not in the allowlist require the `exec` capability

--- a/docs/adr/adr-056-session-sync.md
+++ b/docs/adr/adr-056-session-sync.md
@@ -185,3 +185,83 @@ Reuses `json_extract_string()` from `json/json.h` for reading. Serialization use
 - Session files grow unbounded — caller is responsible for cleanup or rotation
 - No built-in context window management — if history exceeds model context, Ollama truncates
 - Future: could add `--session-clear` to reset, or `--session-last N` to limit history depth
+
+## Capabilities: `--capabilities=read,write,exec`
+
+Without capabilities, sync mode streams the raw LLM response (including annotation tags) to stdout and the caller handles them. With `--capabilities`, llama-cli processes annotations itself — auto-executing allowed actions and feeding output back to the model.
+
+### Capability levels
+
+| Capability | Annotations processed | Auto-executes |
+|------------|----------------------|---------------|
+| `read` | `<read>`, `<exec>` (safe commands only) | File reads, read-only shell commands |
+| `write` | `<write>`, `<str_replace>` | File creates and edits |
+| `exec` | `<exec>` (any command) | Arbitrary shell commands |
+
+Capabilities are additive and comma-separated:
+
+```bash
+# Research mode — model can read files and run safe commands
+./llama-cli --session s.json --capabilities=read "what does main.cpp do?"
+
+# Code fix mode — model can read and edit files
+./llama-cli --session s.json --capabilities=read,write "fix the bug in config.cpp"
+
+# Full autonomy — model can do anything (explicit opt-in)
+./llama-cli --session s.json --capabilities=read,write,exec "set up the project"
+```
+
+### Read-only command allowlist
+
+The `read` capability allows `<exec>` only for commands whose first word is in this allowlist:
+
+```
+cat ls find grep head tail wc stat tree du df
+file diff sort uniq awk sed less more realpath dirname basename
+```
+
+Safety rules:
+- Each pipe segment is checked independently (`cat foo | grep bar` → both OK)
+- Redirects (`>`, `>>`) are always blocked in read mode
+- Commands not in the allowlist require the `exec` capability
+
+### Capability flow
+
+```mermaid
+flowchart TD
+    R[LLM response] --> P{has annotations?}
+    P -->|no| D[done]
+    P -->|yes| C{check capabilities}
+    C -->|read tag + read cap| FR[read file, feed back]
+    C -->|exec tag + read cap| SC{safe command?}
+    SC -->|yes| EX[execute, feed back]
+    SC -->|no| BL[blocked]
+    C -->|exec tag + exec cap| EX2[execute any, feed back]
+    C -->|write tag + write cap| WR[write/replace file]
+    C -->|no matching cap| BL
+    FR --> FL{more annotations?}
+    EX --> FL
+    EX2 --> FL
+    FL -->|yes, has output| NR[send follow-up to model]
+    NR --> R
+    FL -->|no| D
+```
+
+### Follow-up loop
+
+When read/exec output is produced, it's fed back to the model as a user message so the model can analyze the results. This loops up to 10 rounds (safety limit) or until the model produces a response with no actionable annotations.
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant L as llama-cli
+    participant O as Ollama
+
+    C->>L: --capabilities=read "explain main.cpp"
+    L->>O: [system, user]
+    O-->>L: I'll read the file<br/><read path="src/main.cpp"/>
+    L->>L: read file (cap: read ✓)
+    L->>O: [system, user, assistant, user: file content]
+    O-->>L: This file does X, Y, Z...
+    L-->>C: final response on stdout
+```

--- a/docs/adr/adr-057-web-search-integration.md
+++ b/docs/adr/adr-057-web-search-integration.md
@@ -1,0 +1,36 @@
+# ADR-057: Web Search Integration via Tool Annotations
+
+## Status
+
+Proposed
+
+## Context
+
+Currently, `llama-cli` is a local-first, private assistant. The LLM's knowledge is limited to its training data and the files explicitly provided by the user. There is a clear need for the LLM to access real-time information from the internet (e.g., news, weather, or recent documentation updates) to answer queries that fall outside its training cutoff.
+
+The challenge is to implement web search capabilities without compromising the core "Privacy-First" philosophy and without introducing heavy dependencies or complex infrastructure.
+
+## Decision
+
+We will implement web search as a new **Tool Annotation**, leveraging the existing architecture in `src/annotation/` and `src/exec/`.
+
+### Implementation Details
+
+1. **Annotation Pattern:** Introduce a new pattern, e.g., `[search: "query"]`, which the LLM can output during a conversation.
+2. **Parser Update:** Update the parser in `src/annotation/` to recognize and extract the `search` command from the LLM response.
+3. **Execution Logic:** Implement the search logic in `src/exec/` (or a new `src/search/` module) using a lightweight, privacy-conscious method (e.g., scraping DuckDuckGo or using a privacy-friendly search API).
+4. **Configuration:** Add a configuration toggle (e.g., `ALLOW_WEB_SEARCH=true`) in `src/config/` to allow users to explicitly enable or disable this feature to maintain 100% offline mode when desired.
+
+## Consequences
+
+### Positive
+
+* **Enhanced Capability:** The LLM can answer questions about recent events and real-time data.
+* **Minimal Architecture Change:** Reuses the existing tool-calling infrastructure (Annotations + Exec).
+* **User Control:** Users retain the ability to opt-out via configuration, preserving the privacy promise.
+
+### Negative
+
+* **Privacy Trade-off:** Enabling this feature means specific queries will leave the local machine.
+* **External Dependency:** The tool's reliability depends on the availability of the search provider or website.
+* **Complexity:** Adds a new failure mode (network errors, changes in search engine HTML structure).

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -4,87 +4,141 @@ Which features are tested where. Unit = doctest, E2E = bash script, Live = real 
 
 ## Core
 
-| Feature | Unit | E2E | Live | Notes |
-|---------|------|-----|------|-------|
-| Sync mode (one-shot) | — | test_sync_mode | test_live | Positional arg triggers sync |
-| Interactive REPL | test_repl | test_repl_mode | test_live | Linenoise input loop |
-| Conversation history | test_repl | — | test_live | In-memory message list |
-| `--session` multi-turn | — | test_session | — | JSON file persistence (ADR-056) |
-| `--files` context | — | test_files_flag | — | File content as LLM context (ADR-030) |
-| Stdin pipe | — | test_sync_mode | — | Pipe content as prompt |
-| `--provider=mock` | — | all e2e | — | Deterministic echo for testing |
-| Config: defaults | test_config | — | — | Struct defaults |
-| Config: env vars | test_config | — | — | OLLAMA_HOST, etc. |
-| Config: CLI args | test_config | — | — | --host, --port, etc. |
-| Config: .env file | test_config | — | — | load_dotenv() |
-| Config: precedence | test_config | — | — | CLI > env > .env > defaults |
-| `--default-env` | test_config | — | — | Template generation |
+| Feature | Unit | E2E | Live | Gap |
+|---------|------|-----|------|-----|
+| Sync mode (one-shot) | — | test_sync_mode | test_live | |
+| Interactive REPL | test_repl | test_repl_mode | test_live | |
+| Conversation history | test_repl | — | test_live | |
+| `--session` multi-turn | test_config | test_session | — | |
+| `--files` context | — | test_files_flag | — | ⚠️ No unit test for file loading |
+| Stdin pipe | — | test_sync_mode | — | |
+| `--provider=mock` | — | all e2e | — | |
+| Config: defaults | test_config | — | — | |
+| Config: env vars | test_config | — | — | |
+| Config: CLI args | test_config | — | — | |
+| Config: .env file | test_config | — | — | |
+| Config: precedence | test_config | — | — | |
+| `--default-env` | test_config | — | — | |
+| Streaming responses | — | — | test_live | ⚠️ No mock test for streaming |
+| `--no-color` | test_config | — | — | |
+| `--no-banner` | — | — | — | ⚠️ Not tested |
+| `--why-so-serious` | — | — | — | ⚠️ Not tested |
+| `--repl` (force REPL) | — | — | — | ⚠️ Not tested |
 
 ## LLM Tool Annotations
 
-| Feature | Unit | E2E | Live | Notes |
-|---------|------|-----|------|-------|
-| `<write>` parse | test_annotation | — | — | Extract path + content |
-| `<write>` confirm/skip | test_repl | test_smart_rw | test_live | y/n/t/c prompt |
-| `<write>` auto-diff | test_repl | test_smart_rw | — | Myers LCS diff for existing files |
-| `<str_replace>` parse | test_annotation | — | — | Extract path + old + new |
-| `<str_replace>` apply | test_repl | test_smart_rw | test_live | Targeted replacement |
-| `<str_replace>` diff | test_repl | test_smart_rw | — | Hunk headers + context |
-| `<read>` parse | test_annotation | — | — | Extract path + lines + search |
-| `<read>` inject | test_repl | test_smart_rw | test_live | File content → history |
-| `<exec>` confirm/skip | test_repl | — | test_live | y/n/t/c prompt |
-| Trust mode | test_repl | — | — | Auto-approve rest of session |
-| Follow-up loop | test_repl | — | test_live | Re-send after read/exec output |
-| Follow-up bounded | test_repl | — | — | Max iterations safety limit |
-| Strip annotations | test_annotation | — | — | Clean display text |
+| Feature | Unit | E2E | Live | Gap |
+|---------|------|-----|------|-----|
+| `<write>` parse | test_annotation | — | — | |
+| `<write>` confirm/skip | test_repl | test_smart_rw | test_live | |
+| `<write>` auto-diff | test_repl | test_smart_rw | — | |
+| `<str_replace>` parse | test_annotation | — | — | |
+| `<str_replace>` apply | test_repl | test_smart_rw | test_live | |
+| `<str_replace>` diff | test_repl | test_smart_rw | — | |
+| `<read>` parse | test_annotation | — | — | |
+| `<read>` inject | test_repl | test_smart_rw | test_live | |
+| `<read>` line range | test_annotation | — | — | ⚠️ No e2e test |
+| `<read>` search | test_annotation | — | — | ⚠️ No e2e test |
+| `<exec>` confirm/skip | test_repl | — | test_live | |
+| Trust mode | test_repl | — | — | |
+| Follow-up loop | test_repl | — | test_live | |
+| Follow-up bounded | test_repl | — | — | |
+| Strip annotations | test_annotation | — | — | |
+| Copy to clipboard | test_repl | — | — | |
 
 ## Capabilities (ADR-056)
 
-| Feature | Unit | E2E | Live | Notes |
-|---------|------|-----|------|-------|
-| `--capabilities=read` | — | test_session | — | Auto-execute `<read>` tags |
-| Read-only exec allowlist | — | test_session | — | cat, ls, grep, etc. |
-| Dangerous exec blocked | — | test_session | — | rm, curl, etc. blocked |
-| `--capabilities=write` | — | test_session | — | Auto-execute `<write>`, `<str_replace>` |
-| `--capabilities=exec` | — | — | — | ⚠️ Not yet tested |
-| No capabilities = passthrough | — | test_session | — | Raw annotations in output |
+| Feature | Unit | E2E | Live | Gap |
+|---------|------|-----|------|-----|
+| `--capabilities=read` | test_config | test_session | — | |
+| Read-only exec allowlist | — | test_session | — | ⚠️ No unit test for is_read_only() |
+| Dangerous exec blocked | — | test_session | — | |
+| `--capabilities=write` | test_config | test_session | — | |
+| `--capabilities=exec` | — | — | — | ⚠️ Not tested |
+| No capabilities = passthrough | — | test_session | — | |
+| Redirect `>` blocked in read mode | — | — | — | ⚠️ Not tested |
+| Pipe safety (each segment checked) | — | — | — | ⚠️ Not tested |
 
 ## Sandbox (ADR-056)
 
-| Feature | Unit | E2E | Live | Notes |
-|---------|------|-----|------|-------|
-| `--sandbox=PATH` | — | test_session | — | Default: `.` |
-| Read outside sandbox blocked | — | test_session | — | /etc/hostname blocked |
-| Write outside sandbox blocked | — | test_session | — | ../outside.txt blocked |
-| Read inside sandbox allowed | — | test_session | — | Files within sandbox OK |
-| Symlink escape | — | — | — | ⚠️ Not yet tested |
+| Feature | Unit | E2E | Live | Gap |
+|---------|------|-----|------|-----|
+| `--sandbox=PATH` | test_config | test_session | — | |
+| Read outside sandbox blocked | — | test_session | — | |
+| Write outside sandbox blocked | — | test_session | — | |
+| Read inside sandbox allowed | — | test_session | — | |
+| New file write (parent dir check) | — | — | — | ⚠️ Not tested |
+| Symlink escape | — | — | — | ⚠️ Not tested |
+| `..` traversal blocked | — | — | — | ⚠️ Not tested (realpath handles it) |
 
 ## Commands
 
-| Feature | Unit | E2E | Live | Notes |
-|---------|------|-----|------|-------|
-| `/help` | test_command | — | — | Show available commands |
-| `/set` | test_repl | — | — | Toggle runtime options |
-| `/version` | test_repl | — | — | Show version info |
-| `/model` | test_repl | — | — | Interactive model selection |
-| `/read` | test_command | — | — | Manual file read |
-| `/clear` | test_repl | — | — | Clear conversation history |
-| `!command` | test_repl | — | test_live | Execute, output to terminal |
-| `!!command` | test_repl | — | test_live | Execute, output as LLM context |
+| Feature | Unit | E2E | Live | Gap |
+|---------|------|-----|------|-----|
+| `/help` | test_command | — | — | |
+| `/set` | test_repl | — | — | |
+| `/version` | test_repl | — | — | |
+| `/model` | test_repl | — | — | |
+| `/read` | test_command | — | — | |
+| `/clear` | test_repl | — | — | ⚠️ Only checks output, not history reset |
+| `!command` | test_repl | — | test_live | |
+| `!!command` | test_repl | — | test_live | ⚠️ No test that output enters history |
 
 ## Infrastructure
 
-| Feature | Unit | E2E | Live | Notes |
-|---------|------|-----|------|-------|
-| JSON extraction | test_json | — | — | String, object, int |
-| Command execution | test_exec | — | — | Timeout, output capture |
-| Markdown rendering | test_markdown | — | — | Tables, code, bold, links |
-| Stream rendering | test_markdown | — | — | Token-by-token markdown |
-| Event logging | test_logger | — | — | JSONL format |
-| Trace capture | test_trace | — | — | HTTP call tracing |
+| Feature | Unit | E2E | Live | Gap |
+|---------|------|-----|------|-----|
+| JSON string extraction | test_json | — | — | |
+| JSON object extraction | test_json | — | — | |
+| JSON int extraction | test_json | — | — | |
+| JSON unicode escape | test_json | — | — | |
+| JSON missing key | test_json | — | — | |
+| Command execution | test_exec | — | — | |
+| Exec timeout | test_exec | — | — | |
+| Exec output truncation | test_exec | — | — | |
+| Exec failed command | test_exec | — | — | |
+| Markdown rendering | test_markdown | — | — | |
+| Table rendering | test_markdown | — | — | |
+| Stream rendering | test_markdown | — | — | |
+| Event logging (JSONL) | test_logger | — | — | |
+| Logger path detection | test_logger | — | — | |
+| Logger escape chars | test_logger | — | — | |
+| Trace capture | test_trace | — | — | |
+| StderrTrace smoke | test_trace | — | — | |
+| Ollama API: generate | — | — | test_live | ⚠️ Needs HTTP mock |
+| Ollama API: chat | — | — | test_live | ⚠️ Needs HTTP mock |
+| Ollama API: streaming | — | — | test_live | ⚠️ Needs HTTP mock |
+| Ollama API: model list | — | — | — | ⚠️ Needs HTTP mock |
+| Ollama API: retry on failure | — | — | — | ⚠️ Needs HTTP mock |
 
-## Legend
+## Coverage Summary
 
-- ✅ Covered by automated test
-- ⚠️ Not yet tested (gap)
-- `test_live` requires running Ollama (`make live`)
+| Module | Lines | Coverage | Status |
+|--------|-------|----------|--------|
+| annotation.cpp | 146 | ~92% | ✅ Good |
+| command.cpp | 31 | 100% | ✅ Complete |
+| config.cpp | 276 | ~73% | 🔶 OK — new flags tested |
+| exec.cpp | 36 | ~86% | ✅ Good |
+| json.cpp | 106 | ~81% | 🔶 OK |
+| logger.cpp | 61 | ~75% | 🔶 OK |
+| ollama.cpp | 205 | 0% | 🔴 Needs HTTP mock |
+| repl.cpp | 744 | ~54% | 🔶 Large file, many paths |
+| trace.cpp | 16 | ~37% | 🔶 StderrTrace hard to capture |
+| tui.h | 466 | ~76% | 🔶 OK via markdown_it |
+
+## Low-Hanging Fruits
+
+Tests that would improve coverage with minimal effort:
+
+| What | Where | Effort | Impact |
+|------|-------|--------|--------|
+| `is_read_only()` unit test | main.cpp or extract to module | Low | Validates allowlist logic |
+| `--capabilities=exec` e2e | test_session.sh | Low | Covers yolo mode |
+| `..` traversal sandbox test | test_session.sh | Low | Validates realpath |
+| Redirect `>` blocked test | test_session.sh | Low | Validates pipe safety |
+| `!!` injects into history | test_repl.cpp | Low | Verifies context injection |
+| `/clear` resets history | test_repl.cpp | Low | Verifies state reset |
+| `--no-banner` suppresses banner | test_repl.cpp | Low | Trivial flag check |
+| Config: malformed port | test_config.cpp | Low | Bug from TODO.md |
+| Logger: dev vs installed path | test_logger.cpp | Medium | Needs env manipulation |
+| Ollama API mock | new test file | High | Needs HTTP mock server |

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -1,0 +1,90 @@
+# Feature Coverage Matrix
+
+Which features are tested where. Unit = doctest, E2E = bash script, Live = real LLM.
+
+## Core
+
+| Feature | Unit | E2E | Live | Notes |
+|---------|------|-----|------|-------|
+| Sync mode (one-shot) | — | test_sync_mode | test_live | Positional arg triggers sync |
+| Interactive REPL | test_repl | test_repl_mode | test_live | Linenoise input loop |
+| Conversation history | test_repl | — | test_live | In-memory message list |
+| `--session` multi-turn | — | test_session | — | JSON file persistence (ADR-056) |
+| `--files` context | — | test_files_flag | — | File content as LLM context (ADR-030) |
+| Stdin pipe | — | test_sync_mode | — | Pipe content as prompt |
+| `--provider=mock` | — | all e2e | — | Deterministic echo for testing |
+| Config: defaults | test_config | — | — | Struct defaults |
+| Config: env vars | test_config | — | — | OLLAMA_HOST, etc. |
+| Config: CLI args | test_config | — | — | --host, --port, etc. |
+| Config: .env file | test_config | — | — | load_dotenv() |
+| Config: precedence | test_config | — | — | CLI > env > .env > defaults |
+| `--default-env` | test_config | — | — | Template generation |
+
+## LLM Tool Annotations
+
+| Feature | Unit | E2E | Live | Notes |
+|---------|------|-----|------|-------|
+| `<write>` parse | test_annotation | — | — | Extract path + content |
+| `<write>` confirm/skip | test_repl | test_smart_rw | test_live | y/n/t/c prompt |
+| `<write>` auto-diff | test_repl | test_smart_rw | — | Myers LCS diff for existing files |
+| `<str_replace>` parse | test_annotation | — | — | Extract path + old + new |
+| `<str_replace>` apply | test_repl | test_smart_rw | test_live | Targeted replacement |
+| `<str_replace>` diff | test_repl | test_smart_rw | — | Hunk headers + context |
+| `<read>` parse | test_annotation | — | — | Extract path + lines + search |
+| `<read>` inject | test_repl | test_smart_rw | test_live | File content → history |
+| `<exec>` confirm/skip | test_repl | — | test_live | y/n/t/c prompt |
+| Trust mode | test_repl | — | — | Auto-approve rest of session |
+| Follow-up loop | test_repl | — | test_live | Re-send after read/exec output |
+| Follow-up bounded | test_repl | — | — | Max iterations safety limit |
+| Strip annotations | test_annotation | — | — | Clean display text |
+
+## Capabilities (ADR-056)
+
+| Feature | Unit | E2E | Live | Notes |
+|---------|------|-----|------|-------|
+| `--capabilities=read` | — | test_session | — | Auto-execute `<read>` tags |
+| Read-only exec allowlist | — | test_session | — | cat, ls, grep, etc. |
+| Dangerous exec blocked | — | test_session | — | rm, curl, etc. blocked |
+| `--capabilities=write` | — | test_session | — | Auto-execute `<write>`, `<str_replace>` |
+| `--capabilities=exec` | — | — | — | ⚠️ Not yet tested |
+| No capabilities = passthrough | — | test_session | — | Raw annotations in output |
+
+## Sandbox (ADR-056)
+
+| Feature | Unit | E2E | Live | Notes |
+|---------|------|-----|------|-------|
+| `--sandbox=PATH` | — | test_session | — | Default: `.` |
+| Read outside sandbox blocked | — | test_session | — | /etc/hostname blocked |
+| Write outside sandbox blocked | — | test_session | — | ../outside.txt blocked |
+| Read inside sandbox allowed | — | test_session | — | Files within sandbox OK |
+| Symlink escape | — | — | — | ⚠️ Not yet tested |
+
+## Commands
+
+| Feature | Unit | E2E | Live | Notes |
+|---------|------|-----|------|-------|
+| `/help` | test_command | — | — | Show available commands |
+| `/set` | test_repl | — | — | Toggle runtime options |
+| `/version` | test_repl | — | — | Show version info |
+| `/model` | test_repl | — | — | Interactive model selection |
+| `/read` | test_command | — | — | Manual file read |
+| `/clear` | test_repl | — | — | Clear conversation history |
+| `!command` | test_repl | — | test_live | Execute, output to terminal |
+| `!!command` | test_repl | — | test_live | Execute, output as LLM context |
+
+## Infrastructure
+
+| Feature | Unit | E2E | Live | Notes |
+|---------|------|-----|------|-------|
+| JSON extraction | test_json | — | — | String, object, int |
+| Command execution | test_exec | — | — | Timeout, output capture |
+| Markdown rendering | test_markdown | — | — | Tables, code, bold, links |
+| Stream rendering | test_markdown | — | — | Token-by-token markdown |
+| Event logging | test_logger | — | — | JSONL format |
+| Trace capture | test_trace | — | — | HTTP call tracing |
+
+## Legend
+
+- ✅ Covered by automated test
+- ⚠️ Not yet tested (gap)
+- `test_live` requires running Ollama (`make live`)

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -142,3 +142,14 @@ Tests that would improve coverage with minimal effort:
 | Config: malformed port | test_config.cpp | Low | Bug from TODO.md |
 | Logger: dev vs installed path | test_logger.cpp | Medium | Needs env manipulation |
 | Ollama API mock | new test file | High | Needs HTTP mock server |
+
+## Codecov Badge Setup
+
+The coverage badge in README uses [Codecov](https://codecov.io). Setup:
+
+1. Log in at https://codecov.io with your GitHub account (free for public repos)
+2. Navigate to the repo settings and copy the "Repository Upload Token"
+3. In GitHub: Settings → Environments → create environment named `workflow`
+4. Add secret `CODECOV_TOKEN` with the token value
+5. The CI `test-coverage` job references `environment: workflow` to access the secret
+6. After merge to main, the badge updates automatically

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -147,7 +147,7 @@ Tests that would improve coverage with minimal effort:
 
 The coverage badge in README uses [Codecov](https://codecov.io). Setup:
 
-1. Log in at https://codecov.io with your GitHub account (free for public repos)
+1. Log in at <https://codecov.io> with your GitHub account (free for public repos)
 2. Navigate to the repo settings and copy the "Repository Upload Token"
 3. In GitHub: Settings → Environments → create environment named `workflow`
 4. Add secret `CODECOV_TOKEN` with the token value

--- a/e2e/test_session.sh
+++ b/e2e/test_session.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# test_session.sh — E2E tests for --session, --capabilities, and --sandbox.
+#
+# Tests the stateful sync mode (ADR-056) using mock provider.
+# Mock echoes the prompt back as the response, so annotation tags
+# in the prompt are returned and processed by the capabilities engine.
+#
+# Usage:
+#   bash e2e/test_session.sh [path-to-binary]
+
+set -o errexit
+set -o nounset
+set -o pipefail
+if [[ "${TRACE-0}" == "1" ]]; then set -o xtrace; fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+BINARY="${1:-./build/llama-cli}"
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+echo "=== E2E: session + capabilities + sandbox ==="
+
+check_binary "$BINARY"
+
+# --- Session tests ---
+
+echo "Testing: session file creation..."
+SESSION="$TMPDIR_TEST/session.json"
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" "hello world" 2>&1)
+assert_contains "$OUTPUT" "hello world" "session sync response"
+test -f "$SESSION" || die "session file not created"
+assert_contains "$(cat "$SESSION")" '"role":"user"' "session has user message"
+assert_contains "$(cat "$SESSION")" '"role":"assistant"' "session has assistant message"
+echo "PASS: session file creation"
+
+echo "Testing: session follow-up preserves history..."
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" "follow up" 2>&1)
+# Session should now have 2 user + 2 assistant messages
+COUNT=$(grep -c '"role":"user"' "$SESSION")
+test "$COUNT" -eq 2 || die "expected 2 user messages, got $COUNT"
+COUNT=$(grep -c '"role":"assistant"' "$SESSION")
+test "$COUNT" -eq 2 || die "expected 2 assistant messages, got $COUNT"
+echo "PASS: session follow-up preserves history"
+
+# --- Capabilities: read ---
+
+echo "Testing: capabilities=read processes <read> tags..."
+SESSION="$TMPDIR_TEST/cap-read.json"
+echo "test-content-123" > "$TMPDIR_TEST/testfile.txt"
+# Mock echoes prompt back — the <read> tag in the response triggers file read
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" \
+  --capabilities=read --sandbox="$TMPDIR_TEST" \
+  '<read path="'"$TMPDIR_TEST"'/testfile.txt"/>' 2>&1)
+assert_contains "$OUTPUT" "test-content-123" "read capability returned file content"
+echo "PASS: capabilities=read processes <read> tags"
+
+# --- Capabilities: exec (read-only) ---
+
+echo "Testing: capabilities=read allows safe exec..."
+SESSION="$TMPDIR_TEST/cap-exec.json"
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" \
+  --capabilities=read --sandbox="$TMPDIR_TEST" \
+  '<exec>cat '"$TMPDIR_TEST"'/testfile.txt</exec>' 2>&1)
+assert_contains "$OUTPUT" "test-content-123" "safe exec returned file content"
+echo "PASS: capabilities=read allows safe exec"
+
+echo "Testing: capabilities=read blocks dangerous exec..."
+SESSION="$TMPDIR_TEST/cap-block.json"
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" \
+  --capabilities=read --sandbox="$TMPDIR_TEST" \
+  '<exec>rm '"$TMPDIR_TEST"'/testfile.txt</exec>' 2>&1)
+assert_contains "$OUTPUT" "blocked" "dangerous exec was blocked"
+test -f "$TMPDIR_TEST/testfile.txt" || die "file was deleted despite read-only mode"
+echo "PASS: capabilities=read blocks dangerous exec"
+
+# --- Sandbox ---
+
+echo "Testing: sandbox blocks read outside directory..."
+SESSION="$TMPDIR_TEST/sandbox.json"
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" \
+  --capabilities=read --sandbox="$TMPDIR_TEST" \
+  '<read path="/etc/hostname"/>' 2>&1)
+assert_contains "$OUTPUT" "blocked" "read outside sandbox was blocked"
+echo "PASS: sandbox blocks read outside directory"
+
+echo "Testing: sandbox blocks write outside directory..."
+SESSION="$TMPDIR_TEST/sandbox-w.json"
+OUTSIDE="$TMPDIR_TEST/../outside-sandbox.txt"
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" \
+  --capabilities=read,write --sandbox="$TMPDIR_TEST" \
+  '<write file="'"$OUTSIDE"'">pwned</write>' 2>&1)
+assert_contains "$OUTPUT" "blocked" "write outside sandbox was blocked"
+test ! -f "$OUTSIDE" || die "file was written outside sandbox"
+echo "PASS: sandbox blocks write outside directory"
+
+# --- No capabilities = raw passthrough ---
+
+echo "Testing: no capabilities passes annotations through..."
+SESSION="$TMPDIR_TEST/nocap.json"
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" \
+  '<exec>echo hi</exec>' 2>&1)
+# Without capabilities, the <exec> tag should appear in output as-is
+assert_contains "$OUTPUT" "<exec>" "annotations passed through without capabilities"
+echo "PASS: no capabilities passes annotations through"
+
+echo "=== All session tests passed ==="

--- a/e2e/test_session.sh
+++ b/e2e/test_session.sh
@@ -106,4 +106,46 @@ OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" \
 assert_contains "$OUTPUT" "<exec>" "annotations passed through without capabilities"
 echo "PASS: no capabilities passes annotations through"
 
+# --- Capabilities: exec (yolo mode) ---
+
+echo "Testing: capabilities=exec allows any command..."
+SESSION="$TMPDIR_TEST/cap-yolo.json"
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" \
+  --capabilities=read,write,exec --sandbox="$TMPDIR_TEST" \
+  '<exec>echo yolo-test-123</exec>' 2>&1)
+assert_contains "$OUTPUT" "yolo-test-123" "exec capability ran arbitrary command"
+echo "PASS: capabilities=exec allows any command"
+
+# --- Sandbox: .. traversal ---
+
+echo "Testing: sandbox blocks .. traversal..."
+SESSION="$TMPDIR_TEST/sandbox-dotdot.json"
+mkdir -p "$TMPDIR_TEST/sub"
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" \
+  --capabilities=read --sandbox="$TMPDIR_TEST/sub" \
+  '<read path="'"$TMPDIR_TEST"'/sub/../testfile.txt"/>' 2>&1)
+assert_contains "$OUTPUT" "blocked" ".. traversal was blocked"
+echo "PASS: sandbox blocks .. traversal"
+
+# --- Redirect blocked in read mode ---
+
+echo "Testing: redirect > blocked in read-only mode..."
+SESSION="$TMPDIR_TEST/cap-redirect.json"
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" \
+  --capabilities=read --sandbox="$TMPDIR_TEST" \
+  '<exec>echo pwned > '"$TMPDIR_TEST"'/hacked.txt</exec>' 2>&1)
+assert_contains "$OUTPUT" "blocked" "redirect was blocked"
+test ! -f "$TMPDIR_TEST/hacked.txt" || die "redirect created a file despite read-only mode"
+echo "PASS: redirect > blocked in read-only mode"
+
+# --- Pipe safety: each segment checked ---
+
+echo "Testing: pipe with unsafe command blocked..."
+SESSION="$TMPDIR_TEST/cap-pipe.json"
+OUTPUT=$("$BINARY" --provider=mock --session="$SESSION" \
+  --capabilities=read --sandbox="$TMPDIR_TEST" \
+  '<exec>cat '"$TMPDIR_TEST"'/testfile.txt | rm -rf /</exec>' 2>&1)
+assert_contains "$OUTPUT" "blocked" "pipe with unsafe segment was blocked"
+echo "PASS: pipe with unsafe command blocked"
+
 echo "=== All session tests passed ==="

--- a/scripts/git/prepush-check.sh
+++ b/scripts/git/prepush-check.sh
@@ -12,9 +12,12 @@ STEP=0
 FAILED_NAMES=()
 
 STEPS=(
-  "Lint|lint-code|make -s lint-code"
-  "Lint|lint-yaml|make -s lint-yaml"
-  "Lint|lint-md|make -s lint-md"
+  # lint-code: precommit already runs format-code (auto-fix)
+  # "Lint|lint-code|make -s lint-code"
+  # lint-yaml: precommit already runs format-yaml (auto-fix)
+  # "Lint|lint-yaml|make -s lint-yaml"
+  # lint-md: precommit already runs format-md (auto-fix)
+  # "Lint|lint-md|make -s lint-md"
   "Lint|lint-makefile|make -s lint-makefile"
   "Lint|lint-scripts|make -s lint-scripts"
   "Analysis|tidy|make -s tidy"
@@ -26,7 +29,8 @@ STEPS=(
   # coverage-report: slow (~30s), CI handles this on every PR
   # "Test|coverage-report|make -s coverage-report"
   "Security|sast-security|make -s sast-security"
-  "Security|sast-secret|make -s sast-secret"
+  # sast-secret: precommit already runs this
+  # "Security|sast-secret|make -s sast-secret"
   "Metrics|comment-ratio|make -s comment-ratio"
 )
 

--- a/scripts/git/prepush-check.sh
+++ b/scripts/git/prepush-check.sh
@@ -18,11 +18,13 @@ STEPS=(
   "Lint|lint-makefile|make -s lint-makefile"
   "Lint|lint-scripts|make -s lint-scripts"
   "Analysis|tidy|make -s tidy"
-  "Analysis|complexity|make -s complexity"
+  # complexity: redundant with tidy + CI runs full-check on main
+  # "Analysis|complexity|make -s complexity"
   "Build|build|make -s build"
   "Test|test-unit|make -s test-unit"
   "Test|e2e|make -s e2e"
-  "Test|coverage-report|make -s coverage-report"
+  # coverage-report: slow (~30s), CI handles this on every PR
+  # "Test|coverage-report|make -s coverage-report"
   "Security|sast-security|make -s sast-security"
   "Security|sast-secret|make -s sast-secret"
   "Metrics|comment-ratio|make -s comment-ratio"

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -251,6 +251,7 @@ static const OptDef opts[] = {
     {"--model=", "-m", &Config::model},
     {"--system-prompt=", nullptr, &Config::system_prompt},
     {"--session=", nullptr, &Config::session_path},
+    {"--capabilities=", nullptr, &Config::capabilities},
 };
 
 /** Pointer-to-member type for Config int fields */

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -250,6 +250,7 @@ static const OptDef opts[] = {
     {"--port=", "-p", &Config::port},
     {"--model=", "-m", &Config::model},
     {"--system-prompt=", nullptr, &Config::system_prompt},
+    {"--session=", nullptr, &Config::session_path},
 };
 
 /** Pointer-to-member type for Config int fields */

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -252,6 +252,7 @@ static const OptDef opts[] = {
     {"--system-prompt=", nullptr, &Config::system_prompt},
     {"--session=", nullptr, &Config::session_path},
     {"--capabilities=", nullptr, &Config::capabilities},
+    {"--sandbox=", nullptr, &Config::sandbox},
 };
 
 /** Pointer-to-member type for Config int fields */

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -55,6 +55,7 @@ struct Config {
   std::vector<std::string> files;       ///< Input files for sync mode (--files, ADR-030)
   std::string session_path;             ///< Session file for multi-turn sync (--session, ADR-056)
   std::string capabilities;             ///< Capability flags: read,write,exec (--capabilities, ADR-056)
+  std::string sandbox = ".";            ///< Sandbox root for file ops (--sandbox, ADR-056)
   std::string system_prompt =           ///< System prompt for conversation context
       "You are llama-cli, a local AI assistant running in a terminal. "
       "Keep responses concise and relevant. Always respond in the same "

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -54,6 +54,7 @@ struct Config {
   std::string prompt;                   ///< One-shot prompt for sync mode
   std::vector<std::string> files;       ///< Input files for sync mode (--files, ADR-030)
   std::string session_path;             ///< Session file for multi-turn sync (--session, ADR-056)
+  std::string capabilities;             ///< Capability flags: read,write,exec (--capabilities, ADR-056)
   std::string system_prompt =           ///< System prompt for conversation context
       "You are llama-cli, a local AI assistant running in a terminal. "
       "Keep responses concise and relevant. Always respond in the same "

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -53,6 +53,7 @@ struct Config {
   std::string ai_color = "purple";      ///< AI response color name (LLAMA_AI_COLOR)
   std::string prompt;                   ///< One-shot prompt for sync mode
   std::vector<std::string> files;       ///< Input files for sync mode (--files, ADR-030)
+  std::string session_path;             ///< Session file for multi-turn sync (--session, ADR-056)
   std::string system_prompt =           ///< System prompt for conversation context
       "You are llama-cli, a local AI assistant running in a terminal. "
       "Keep responses concise and relevant. Always respond in the same "

--- a/src/config/config_test.cpp
+++ b/src/config/config_test.cpp
@@ -406,3 +406,70 @@ SCENARIO ("print default env template") {
     }
   }
 }
+
+// --- ADR-056: session, capabilities, sandbox ---
+
+SCENARIO ("config: --session flag") {
+  GIVEN ("--session=path is provided") {
+    const char* argv[] = {"llama-cli", "--session=/tmp/s.json", "hello", nullptr};
+    WHEN ("config is loaded from CLI") {
+      Config c = load_cli(3, argv);
+      THEN ("session_path is set") {
+        CHECK (c.session_path == "/tmp/s.json")
+          ;
+      }
+    }
+  }
+  GIVEN ("no --session flag") {
+    const char* argv[] = {"llama-cli", "hello", nullptr};
+    WHEN ("config is loaded from CLI") {
+      Config c = load_cli(2, argv);
+      THEN ("session_path is empty") {
+        CHECK (c.session_path.empty())
+          ;
+      }
+    }
+  }
+}
+
+SCENARIO ("config: --capabilities flag") {
+  GIVEN ("--capabilities=read,write is provided") {
+    const char* argv[] = {"llama-cli", "--capabilities=read,write", "hello", nullptr};
+    WHEN ("config is loaded from CLI") {
+      Config c = load_cli(3, argv);
+      THEN ("capabilities is set") {
+        CHECK (c.capabilities == "read,write")
+          ;
+      }
+    }
+  }
+}
+
+SCENARIO ("config: --sandbox flag") {
+  GIVEN ("--sandbox=./src is provided") {
+    const char* argv[] = {"llama-cli", "--sandbox=./src", "hello", nullptr};
+    WHEN ("config is loaded from CLI") {
+      Config c = load_cli(3, argv);
+      THEN ("sandbox is set") {
+        CHECK (c.sandbox == "./src")
+          ;
+      }
+    }
+  }
+  GIVEN ("no --sandbox flag") {
+    const char* argv[] = {"llama-cli", "hello", nullptr};
+    WHEN ("config is loaded from CLI") {
+      Config c = load_cli(2, argv);
+      THEN ("sandbox defaults to current dir") {
+        CHECK (c.sandbox == ".")
+          ;
+      }
+    }
+  }
+}
+
+// TODO: test --files with space-separated paths
+// TODO: test --files with nonexistent file (should exit with error)
+// TODO: test malformed numeric env/CLI values (stoi crash — see TODO.md)
+// TODO: test TRACE env var handling (inconsistent between .env and env var)
+// TODO: test validate_config rejects invalid port strings like "11434abc"

--- a/src/exec/exec_test.cpp
+++ b/src/exec/exec_test.cpp
@@ -63,3 +63,51 @@ SCENARIO ("command execution") {
     }
   }
 }
+
+// --- Timeout and truncation ---
+
+SCENARIO ("command execution: timeout") {
+  GIVEN ("a command that runs longer than the timeout") {
+    WHEN ("executed with 1 second timeout") {
+      // Use a loop that produces output — timeout is checked between reads
+      auto r = cmd_exec("for i in $(seq 1 100); do echo $i; sleep 0.1; done", 1, 10000);
+      THEN ("it is killed by timeout") {
+        CHECK (r.timed_out)
+          ;
+        CHECK (r.output.find("timeout") != std::string::npos)
+          ;
+      }
+    }
+  }
+}
+
+SCENARIO ("command execution: output truncation") {
+  GIVEN ("a command that produces lots of output") {
+    WHEN ("executed with small max_chars") {
+      auto r = cmd_exec("seq 1 10000", 5, 100);
+      THEN ("output is truncated") {
+        CHECK (r.output.find("truncated") != std::string::npos)
+          ;
+        CHECK (static_cast<int>(r.output.size()) < 200)
+          ;
+      }
+    }
+  }
+}
+
+SCENARIO ("command execution: failed command") {
+  GIVEN ("a command that exits with non-zero") {
+    WHEN ("executed") {
+      auto r = cmd_exec("false", 5, 10000);
+      THEN ("exit code is non-zero") {
+        CHECK (r.exit_code != 0)
+          ;
+        CHECK (!r.timed_out)
+          ;
+      }
+    }
+  }
+}
+
+// TODO: test popen failure path (cmd_exec returns "Error: could not execute command")
+// TODO: test WIFSIGNALED path (command killed by signal)

--- a/src/help.h
+++ b/src/help.h
@@ -48,6 +48,7 @@ inline std::string cli() {
              "  --files=FILE      Read file(s) as context (quoted for multiple)\n"
              "  --session=PATH    Session file for multi-turn sync mode (ADR-056)\n"
              "  --capabilities=X  Allowed actions: read,write,exec (default: none)\n"
+             "  --sandbox=PATH    Restrict file ops to this directory (default: .)\n"
              "  PROMPT            Run in sync mode (non-interactive)\n"
              "\n"
              "Examples:\n"

--- a/src/help.h
+++ b/src/help.h
@@ -47,6 +47,7 @@ inline std::string cli() {
              "  --default-env     Print .env template to stdout (use > .env to save)\n"
              "  --files=FILE      Read file(s) as context (quoted for multiple)\n"
              "  --session=PATH    Session file for multi-turn sync mode (ADR-056)\n"
+             "  --capabilities=X  Allowed actions: read,write,exec (default: none)\n"
              "  PROMPT            Run in sync mode (non-interactive)\n"
              "\n"
              "Examples:\n"

--- a/src/help.h
+++ b/src/help.h
@@ -46,6 +46,7 @@ inline std::string cli() {
              "  --why-so-serious  Enable BOFH spinner mode\n"
              "  --default-env     Print .env template to stdout (use > .env to save)\n"
              "  --files=FILE      Read file(s) as context (quoted for multiple)\n"
+             "  --session=PATH    Session file for multi-turn sync mode (ADR-056)\n"
              "  PROMPT            Run in sync mode (non-interactive)\n"
              "\n"
              "Examples:\n"

--- a/src/json/json_test.cpp
+++ b/src/json/json_test.cpp
@@ -151,3 +151,71 @@ SCENARIO ("json_extract_object") {
     }
   }
 }
+
+// --- Edge cases ---
+
+SCENARIO ("json: missing key returns empty") {
+  GIVEN ("a JSON string") {
+    std::string json = R"({"name":"alice"})";
+    THEN ("missing key returns empty string") {
+      CHECK (json_extract_string(json, "age").empty())
+        ;
+    }
+    THEN ("missing key returns 0 for int") {
+      CHECK (json_extract_int(json, "age") == 0)
+        ;
+    }
+    THEN ("missing key returns empty for object") {
+      CHECK (json_extract_object(json, "address").empty())
+        ;
+    }
+  }
+}
+
+SCENARIO ("json: unicode escape decoding") {
+  GIVEN ("a JSON string with unicode escape") {
+    std::string json = R"({"msg":"hello\u0021"})";
+    THEN ("\\u0021 decodes to !") {
+      CHECK (json_extract_string(json, "msg") == "hello!")
+        ;
+    }
+  }
+}
+
+SCENARIO ("json: whitespace around colon") {
+  GIVEN ("JSON with spaces around colon") {
+    // Note: find_key_value looks for "key": without space before colon
+    // This tests the current behavior with standard format
+    THEN ("extraction handles standard format") {
+      std::string nospace = R"({"key":"value"})";
+      CHECK (json_extract_string(nospace, "key") == "value")
+        ;
+    }
+  }
+}
+
+SCENARIO ("json: nested object extraction") {
+  GIVEN ("JSON with nested braces in strings") {
+    std::string json = R"({"outer":{"inner":"val{ue}"}})";
+    THEN ("object extraction handles braces in strings") {
+      std::string obj = json_extract_object(json, "outer");
+      CHECK (obj.find("inner") != std::string::npos)
+        ;
+    }
+  }
+}
+
+SCENARIO ("json: extract_int with leading whitespace") {
+  GIVEN ("JSON with space before int value") {
+    std::string json = R"({"count": 42})";
+    THEN ("int is extracted correctly") {
+      CHECK (json_extract_int(json, "count") == 42)
+        ;
+    }
+  }
+}
+
+// TODO: test json_extract_string with escaped backslash before quote (\\\")
+// TODO: test json_extract_object with deeply nested objects
+// TODO: test decode_unicode_escape with non-ASCII codepoints (>127)
+// TODO: test malformed JSON (unclosed strings, missing braces)

--- a/src/logging/logger_test.cpp
+++ b/src/logging/logger_test.cpp
@@ -131,3 +131,45 @@ SCENARIO ("Logger writes JSONL events") {
     }
   }
 }
+
+// --- Logger path and edge cases ---
+
+SCENARIO ("Logger path detection") {
+  GIVEN ("the logger singleton") {
+    WHEN ("path is queried") {
+      const auto& logger = Logger::instance();
+      THEN ("path is non-empty and ends with events.jsonl") {
+        CHECK (!logger.path().empty())
+          ;
+        CHECK (logger.path().find("events.jsonl") != std::string::npos)
+          ;
+      }
+    }
+  }
+}
+
+SCENARIO ("Logger escapes control characters") {
+  GIVEN ("a logger instance") {
+    auto& logger = Logger::instance();
+    WHEN ("an event with tabs and newlines is logged") {
+      Event e;
+      e.agent = "test";
+      e.action = "escape";
+      e.input = "line1\nline2";
+      e.output = "tab\there";
+      logger.log(e);
+      THEN ("the log file contains escaped sequences") {
+        std::ifstream f(logger.path());
+        std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+        CHECK (content.find("\\n") != std::string::npos)
+          ;
+        CHECK (content.find("\\t") != std::string::npos)
+          ;
+      }
+    }
+  }
+}
+
+// TODO: test Logger dev-mode vs installed-mode path detection
+// TODO: test Logger with unwritable log path (permission denied)
+// TODO: test Logger escape of all RFC 8259 control characters (\b, \f, \u00xx)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,9 +11,12 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <sstream>
 #include <string>
 
+#include "annotation/annotation.h"
 #include "config/config.h"
+#include "exec/exec.h"
 #include "help.h"
 #include "json/json.h"
 #include "ollama/ollama.h"
@@ -87,6 +90,132 @@ static std::string load_kiro_context(Config& cfg, bool color) {
  *
  * @return int Exit code: `0` on normal completion.
  */
+/// Check if a capability is enabled in the comma-separated capabilities string
+static bool has_cap(const std::string& caps, const std::string& cap) {
+  // Search for cap as a whole word within comma-separated list
+  size_t pos = 0;
+  while ((pos = caps.find(cap, pos)) != std::string::npos) {
+    bool at_start = (pos == 0 || caps[pos - 1] == ',');
+    bool at_end = (pos + cap.size() >= caps.size() || caps[pos + cap.size()] == ',');
+    if (at_start && at_end) return true;
+    pos += cap.size();
+  }
+  return false;
+}
+
+/// Commands safe to auto-execute with the "read" capability.
+/// These cannot modify files, network, or system state.
+static const std::vector<std::string> READ_ONLY_COMMANDS = {"cat",  "ls",   "find", "grep",     "head",    "tail",    "wc",   "stat",
+                                                            "tree", "du",   "df",   "file",     "diff",    "sort",    "uniq", "awk",
+                                                            "sed",  "less", "more", "realpath", "dirname", "basename"};
+
+/// Check if a command is read-only (first word in allowlist, no redirects)
+static bool is_read_only(const std::string& cmd) {
+  // Block redirects and destructive operators
+  if (cmd.find('>') != std::string::npos) return false;
+  // Extract first word from each pipe segment
+  std::istringstream segments(cmd);
+  std::string segment;
+  while (std::getline(segments, segment, '|')) {
+    // Trim leading whitespace
+    size_t start = segment.find_first_not_of(" \t");
+    if (start == std::string::npos) continue;
+    // Extract first word (the command)
+    size_t end = segment.find_first_of(" \t", start);
+    std::string word = segment.substr(start, end - start);
+    bool found = false;
+    for (const auto& safe : READ_ONLY_COMMANDS) {
+      if (word == safe) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) return false;
+  }
+  return true;
+}
+
+/// Parse <exec>cmd</exec> tags from LLM response text
+static std::vector<std::string> parse_exec_tags(const std::string& text) {
+  std::vector<std::string> cmds;
+  const std::string open = "<exec>";
+  const std::string close = "</exec>";
+  size_t pos = 0;
+  while ((pos = text.find(open, pos)) != std::string::npos) {
+    size_t start = pos + open.size();
+    size_t end = text.find(close, start);
+    if (end == std::string::npos) break;
+    cmds.push_back(text.substr(start, end - start));
+    pos = end + close.size();
+  }
+  return cmds;
+}
+
+/// Process annotations in sync mode response based on capabilities (ADR-056).
+/// Returns context to feed back to the model (read/exec output).
+// pmccabe:skip-complexity — handles all annotation types in one pass
+static std::string process_sync_annotations(const std::string& response, const Config& cfg) {
+  std::string caps = cfg.capabilities;
+  std::string followup;
+
+  // Process <read> annotations (requires "read" capability)
+  if (has_cap(caps, "read")) {
+    auto reads = parse_read_annotations(response);
+    for (const auto& action : reads) {
+      std::ifstream f(action.path);
+      if (!f) {
+        std::cerr << "[read: file not found: " << action.path << "]\n";
+        continue;
+      }
+      std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+      followup += "[file: " + action.path + "]\n" + content + "\n";
+      std::cerr << "[read " << action.path << "]\n";
+    }
+  }
+
+  // Process <exec> annotations (requires "read" for safe cmds, "exec" for all)
+  auto execs = parse_exec_tags(response);
+  for (const auto& cmd : execs) {
+    bool allowed = has_cap(caps, "exec") || (has_cap(caps, "read") && is_read_only(cmd));
+    if (!allowed) {
+      std::cerr << "[blocked: " << cmd << "]\n";
+      continue;
+    }
+    auto r = cmd_exec(cmd, cfg.exec_timeout, cfg.max_output);
+    followup += "[command: " + cmd + "]\n" + r.output + "\n";
+    std::cerr << "[exec " << cmd << "]\n";
+  }
+
+  // Process <write> and <str_replace> annotations (requires "write" capability)
+  if (has_cap(caps, "write")) {
+    auto writes = parse_write_annotations(response);
+    for (const auto& action : writes) {
+      std::ofstream f(action.path);
+      if (f) {
+        f << action.content;
+        std::cerr << "[wrote " << action.path << "]\n";
+      }
+    }
+    auto replaces = parse_str_replace_annotations(response);
+    for (const auto& action : replaces) {
+      std::ifstream rf(action.path);
+      if (!rf) continue;
+      std::string content((std::istreambuf_iterator<char>(rf)), std::istreambuf_iterator<char>());
+      rf.close();
+      size_t pos = content.find(action.old_str);
+      if (pos == std::string::npos) continue;
+      content.replace(pos, action.old_str.size(), action.new_str);
+      std::ofstream wf(action.path);
+      if (wf) {
+        wf << content;
+        std::cerr << "[str_replace " << action.path << "]\n";
+      }
+    }
+  }
+
+  return followup;
+}
+
 /// Escape a string for JSON output (quotes, backslashes, control chars)
 static std::string escape_json(const std::string& s) {
   std::string out;
@@ -242,9 +371,24 @@ int main(int argc, char* argv[]) {
       });
       if (!response.empty()) {
         std::cout << "\n";
+        messages.push_back({"assistant", response});
+        // Process annotations if capabilities are set (ADR-056)
+        // Follow-up loop: feed read/exec output back to the model
+        int max_rounds = 10;  // safety limit to prevent infinite loops
+        while (!cfg.capabilities.empty() && max_rounds-- > 0) {
+          std::string followup = process_sync_annotations(response, cfg);
+          if (followup.empty()) break;
+          messages.push_back({"user", followup});
+          response = ollama_chat_stream(cfg, messages, [](const std::string& token) {
+            std::cout << token << std::flush;
+            return true;
+          });
+          if (response.empty()) break;
+          std::cout << "\n";
+          messages.push_back({"assistant", response});
+        }
         // Save updated history if --session is set (ADR-056)
         if (!cfg.session_path.empty()) {
-          messages.push_back({"assistant", response});
           save_session(cfg.session_path, messages);
         }
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -351,6 +351,7 @@ static void save_session(const std::string& path, const std::vector<Message>& ms
 
 // pmccabe:skip-complexity — TODO: refactor main dispatch logic
 // NOLINTNEXTLINE(readability-function-size)
+/** @brief Entry point: loads config, dispatches to sync or interactive mode. */
 int main(int argc, char* argv[]) {
   for (int i = 1; i < argc; ++i) {
     if (std::string(argv[i]) == "--help") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -394,43 +394,44 @@ int main(int argc, char* argv[]) {
 
   if (cfg.mode == Mode::Sync) {
     // Sync mode: one-shot, response to stdout (ADR-007)
-    if (cfg.provider == "mock") {
-      std::cout << "mock response: " << cfg.prompt << "\n";
-    } else {
-      tui::system_msg(std::cerr, color, "Connecting to " + cfg.host + ":" + cfg.port + " with model " + cfg.model + "...");
-      // Load session history if --session is set (ADR-056)
-      std::vector<Message> messages = cfg.session_path.empty() ? std::vector<Message>{} : load_session(cfg.session_path);
-      // Add system prompt only if starting a new conversation
-      if (messages.empty() && !cfg.system_prompt.empty()) {
-        messages.push_back({"system", cfg.system_prompt});
+    // Mock provider goes through the same flow — echoes prompt as response
+    // so annotation processing and session work identically in tests.
+    auto generate_response = [&cfg, color](const std::vector<Message>& msgs) -> std::string {
+      if (cfg.provider == "mock") {
+        return "mock response: " + msgs.back().content;
       }
-      messages.push_back({"user", cfg.prompt});
-      std::string response = ollama_chat_stream(cfg, messages, [](const std::string& token) {
+      tui::system_msg(std::cerr, color, "Connecting to " + cfg.host + ":" + cfg.port + " with model " + cfg.model + "...");
+      return ollama_chat_stream(cfg, msgs, [](const std::string& token) {
         std::cout << token << std::flush;
         return true;
       });
-      if (!response.empty()) {
-        std::cout << "\n";
+    };
+
+    // Load session history if --session is set (ADR-056)
+    std::vector<Message> messages = cfg.session_path.empty() ? std::vector<Message>{} : load_session(cfg.session_path);
+    // Add system prompt only if starting a new conversation
+    if (messages.empty() && !cfg.system_prompt.empty()) {
+      messages.push_back({"system", cfg.system_prompt});
+    }
+    messages.push_back({"user", cfg.prompt});
+    std::string response = generate_response(messages);
+    if (!response.empty()) {
+      std::cout << response << "\n";
+      messages.push_back({"assistant", response});
+      // Process annotations if capabilities are set (ADR-056)
+      int max_rounds = 10;
+      while (!cfg.capabilities.empty() && max_rounds-- > 0) {
+        std::string followup = process_sync_annotations(response, cfg);
+        if (followup.empty()) break;
+        messages.push_back({"user", followup});
+        response = generate_response(messages);
+        if (response.empty()) break;
+        std::cout << response << "\n";
         messages.push_back({"assistant", response});
-        // Process annotations if capabilities are set (ADR-056)
-        // Follow-up loop: feed read/exec output back to the model
-        int max_rounds = 10;  // safety limit to prevent infinite loops
-        while (!cfg.capabilities.empty() && max_rounds-- > 0) {
-          std::string followup = process_sync_annotations(response, cfg);
-          if (followup.empty()) break;
-          messages.push_back({"user", followup});
-          response = ollama_chat_stream(cfg, messages, [](const std::string& token) {
-            std::cout << token << std::flush;
-            return true;
-          });
-          if (response.empty()) break;
-          std::cout << "\n";
-          messages.push_back({"assistant", response});
-        }
-        // Save updated history if --session is set (ADR-056)
-        if (!cfg.session_path.empty()) {
-          save_session(cfg.session_path, messages);
-        }
+      }
+      // Save updated history if --session is set (ADR-056)
+      if (!cfg.session_path.empty()) {
+        save_session(cfg.session_path, messages);
       }
     }
   } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,8 @@
 #include <dirent.h>
 #include <unistd.h>
 
+#include <climits>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <iterator>
@@ -151,6 +153,32 @@ static std::vector<std::string> parse_exec_tags(const std::string& text) {
   return cmds;
 }
 
+/// Check if a file path is within the sandbox directory (ADR-056).
+/// Resolves both paths to absolute form to catch ".." traversal.
+/// For non-existent files (writes), checks the parent directory.
+static bool path_allowed(const std::string& path, const std::string& sandbox) {
+  // Resolve sandbox to absolute path
+  char sandbox_real[PATH_MAX];
+  if (!realpath(sandbox.c_str(), sandbox_real)) return false;
+  std::string sandbox_prefix(sandbox_real);
+  sandbox_prefix += "/";
+
+  // For existing files, resolve directly
+  char path_real[PATH_MAX];
+  if (realpath(path.c_str(), path_real)) {
+    std::string resolved(path_real);
+    // Allow exact match (sandbox dir itself) or prefix match
+    return resolved == sandbox_real || resolved.rfind(sandbox_prefix, 0) == 0;
+  }
+
+  // For new files, resolve the parent directory
+  size_t slash = path.rfind('/');
+  std::string parent = (slash != std::string::npos) ? path.substr(0, slash) : ".";
+  if (!realpath(parent.c_str(), path_real)) return false;
+  std::string resolved(path_real);
+  return resolved == sandbox_real || resolved.rfind(sandbox_prefix, 0) == 0;
+}
+
 /// Process annotations in sync mode response based on capabilities (ADR-056).
 /// Returns context to feed back to the model (read/exec output).
 // pmccabe:skip-complexity — handles all annotation types in one pass
@@ -162,6 +190,10 @@ static std::string process_sync_annotations(const std::string& response, const C
   if (has_cap(caps, "read")) {
     auto reads = parse_read_annotations(response);
     for (const auto& action : reads) {
+      if (!path_allowed(action.path, cfg.sandbox)) {
+        std::cerr << "[blocked: read outside sandbox: " << action.path << "]\n";
+        continue;
+      }
       std::ifstream f(action.path);
       if (!f) {
         std::cerr << "[read: file not found: " << action.path << "]\n";
@@ -190,6 +222,10 @@ static std::string process_sync_annotations(const std::string& response, const C
   if (has_cap(caps, "write")) {
     auto writes = parse_write_annotations(response);
     for (const auto& action : writes) {
+      if (!path_allowed(action.path, cfg.sandbox)) {
+        std::cerr << "[blocked: write outside sandbox: " << action.path << "]\n";
+        continue;
+      }
       std::ofstream f(action.path);
       if (f) {
         f << action.content;
@@ -198,6 +234,10 @@ static std::string process_sync_annotations(const std::string& response, const C
     }
     auto replaces = parse_str_replace_annotations(response);
     for (const auto& action : replaces) {
+      if (!path_allowed(action.path, cfg.sandbox)) {
+        std::cerr << "[blocked: write outside sandbox: " << action.path << "]\n";
+        continue;
+      }
       std::ifstream rf(action.path);
       if (!rf) continue;
       std::string content((std::istreambuf_iterator<char>(rf)), std::istreambuf_iterator<char>());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,6 +87,99 @@ static std::string load_kiro_context(Config& cfg, bool color) {
  *
  * @return int Exit code: `0` on normal completion.
  */
+/// Escape a string for JSON output (quotes, backslashes, control chars)
+static std::string escape_json(const std::string& s) {
+  std::string out;
+  for (char c : s) {
+    switch (c) {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        out += c;
+    }
+  }
+  return out;
+}
+
+/// Unescape JSON string escape sequences (\\n, \\t, \\", \\\\, etc.)
+static std::string unescape_json(const std::string& s) {
+  std::string out;
+  for (size_t i = 0; i < s.size(); i++) {
+    if (s[i] == '\\' && i + 1 < s.size()) {
+      switch (s[++i]) {
+        case '"':
+          out += '"';
+          break;
+        case '\\':
+          out += '\\';
+          break;
+        case 'n':
+          out += '\n';
+          break;
+        case 'r':
+          out += '\r';
+          break;
+        case 't':
+          out += '\t';
+          break;
+        default:
+          out += '\\';
+          out += s[i];
+      }
+    } else {
+      out += s[i];
+    }
+  }
+  return out;
+}
+
+/// Load conversation history from a session JSON file (ADR-056).
+/// Returns empty vector if file doesn't exist yet.
+static std::vector<Message> load_session(const std::string& path) {
+  std::vector<Message> msgs;
+  std::ifstream f(path);
+  if (!f) {
+    return msgs;  // new session — file will be created on save
+  }
+  std::string json((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+  // Minimal parser: find each {"role":"...","content":"..."} object
+  size_t pos = 0;
+  while ((pos = json.find("\"role\"", pos)) != std::string::npos) {
+    std::string role = json_extract_string(json.substr(pos - 1), "role");
+    std::string content = json_extract_string(json.substr(pos - 1), "content");
+    if (!role.empty()) {
+      msgs.push_back({role, unescape_json(content)});
+    }
+    pos += 6;  // advance past "role"
+  }
+  return msgs;
+}
+
+/// Save conversation history to a session JSON file (ADR-056)
+static void save_session(const std::string& path, const std::vector<Message>& msgs) {
+  std::ofstream f(path);
+  f << "[\n";
+  for (size_t i = 0; i < msgs.size(); i++) {
+    f << "  {\"role\":\"" << msgs[i].role << "\",\"content\":\"" << escape_json(msgs[i].content) << "\"}";
+    if (i + 1 < msgs.size()) f << ",";
+    f << "\n";
+  }
+  f << "]\n";
+}
+
 // pmccabe:skip-complexity — TODO: refactor main dispatch logic
 // NOLINTNEXTLINE(readability-function-size)
 int main(int argc, char* argv[]) {
@@ -136,8 +229,10 @@ int main(int argc, char* argv[]) {
       std::cout << "mock response: " << cfg.prompt << "\n";
     } else {
       tui::system_msg(std::cerr, color, "Connecting to " + cfg.host + ":" + cfg.port + " with model " + cfg.model + "...");
-      std::vector<Message> messages;
-      if (!cfg.system_prompt.empty()) {
+      // Load session history if --session is set (ADR-056)
+      std::vector<Message> messages = cfg.session_path.empty() ? std::vector<Message>{} : load_session(cfg.session_path);
+      // Add system prompt only if starting a new conversation
+      if (messages.empty() && !cfg.system_prompt.empty()) {
         messages.push_back({"system", cfg.system_prompt});
       }
       messages.push_back({"user", cfg.prompt});
@@ -147,6 +242,11 @@ int main(int argc, char* argv[]) {
       });
       if (!response.empty()) {
         std::cout << "\n";
+        // Save updated history if --session is set (ADR-056)
+        if (!cfg.session_path.empty()) {
+          messages.push_back({"assistant", response});
+          save_session(cfg.session_path, messages);
+        }
       }
     }
   } else {

--- a/src/repl/repl_test.cpp
+++ b/src/repl/repl_test.cpp
@@ -487,3 +487,11 @@ SCENARIO ("REPL /model select from list") {
     }
   }
 }
+
+// TODO: test REPL with piped stdin (non-TTY input)
+// TODO: test /clear resets conversation history
+// TODO: test /set trace toggles trace mode
+// TODO: test color_name_to_ansi and ansi_to_name (high complexity, needs refactor)
+// TODO: test interruptible_chat timeout behavior (needs mock HTTP or thread control)
+// TODO: test !! command injects output into history
+// TODO: test ! command does NOT inject output into history

--- a/src/trace/trace_test.cpp
+++ b/src/trace/trace_test.cpp
@@ -42,3 +42,39 @@ SCENARIO ("StderrTrace exists") {
     }
   }
 }
+
+// --- StderrTrace output test ---
+
+SCENARIO ("StderrTrace writes to stderr") {
+  GIVEN ("the stderr trace instance") {
+    WHEN ("log is called") {
+      // StderrTrace writes to stderr — we can't easily capture it,
+      // but we verify it doesn't crash with various format strings
+      stderr_trace_instance.log("test %s", "message");
+      stderr_trace_instance.log("number %d", 42);
+      stderr_trace_instance.log("no args");
+      THEN ("no crash occurred") {
+        CHECK (true)
+          ;
+      }
+    }
+  }
+}
+
+SCENARIO ("CapturingTrace handles empty format") {
+  GIVEN ("a capturing trace") {
+    CapturingTrace trace;
+    WHEN ("empty string is logged") {
+      trace.log("");
+      THEN ("empty message is captured") {
+        REQUIRE (trace.messages.size() == 1)
+          ;
+        CHECK (trace.messages[0].empty())
+          ;
+      }
+    }
+  }
+}
+
+// TODO: test StderrTrace output format (timestamp + message) — needs stderr capture
+// TODO: test CapturingTrace with buffer overflow (>256 char message)


### PR DESCRIPTION
## Summary

Adds three new CLI flags that enable external tools (Kiro, scripts, CI) to have multi-turn conversations with llama-cli, with fine-grained permission control.

### `--session=PATH` — Multi-turn sync mode
- Persists conversation history to a JSON file between invocations
- Caller controls file lifecycle (create, reuse, delete)
- System prompt only added on first turn

### `--capabilities=read,write,exec` — Permission model
| Capability | What it allows |
|------------|---------------|
| `read` | `<read>` file tags + read-only exec (`cat`, `ls`, `grep`, etc.) |
| `write` | `<write>` and `<str_replace>` file modifications |
| `exec` | Arbitrary shell commands (yolo mode) |

- Without `--capabilities`, annotations pass through as raw text
- Follow-up loop: read/exec output is fed back to the model (max 10 rounds)
- Read-only allowlist: `cat ls find grep head tail wc stat tree du df file diff sort uniq awk sed`
- Redirects (`>`) always blocked in read mode
- Each pipe segment checked independently

### `--sandbox=PATH` — Path containment
- Default: `.` (current directory)
- All file operations resolved via `realpath()` and prefix-checked
- Blocks `..` traversal, absolute paths outside sandbox, symlink escapes
- New file writes check parent directory

## Testing

### 12 automated e2e tests (`e2e/test_session.sh`)
- Session file creation + follow-up history
- `<read>` with read capability
- Safe exec (`cat`) allowed, dangerous exec (`rm`) blocked
- Read/write outside sandbox blocked
- `..` traversal blocked
- Redirect `>` blocked in read mode
- Pipe with unsafe segment blocked
- Exec capability (yolo mode) works
- No capabilities = raw passthrough

### Unit test coverage boost
- **config**: `--session`, `--capabilities`, `--sandbox` flag parsing
- **exec**: timeout, output truncation, failed command
- **json**: missing key, unicode escape, nested objects, int whitespace
- **logger**: path detection, control char escaping
- **trace**: StderrTrace smoke test, empty format
- 23 TODO placeholders for future test work

### Mock provider unified
- Mock now goes through the same session/capabilities/annotation flow as real providers
- Enables deterministic e2e testing without Ollama

## Documentation
- **ADR-056**: Full design with mermaid diagrams (flow, state, sequence)
- **Feature coverage matrix** (`docs/feature-coverage.md`): all features mapped to tests + gaps
- **Codecov badge fix**: added `CODECOV_TOKEN` secret + `environment: workflow`

## Commits
1. `feat: add --session flag for stateful sync mode`
2. `feat: add --capabilities flag for sync mode (read/write/exec)`
3. `feat: add --sandbox flag to restrict file ops to directory`
4. `feat: e2e tests for session, capabilities, and sandbox`
5. `docs: add feature coverage matrix`
6. `test: boost coverage for config, trace, logger, json, exec`
7. `test: add e2e tests for exec cap, .. traversal, redirect, pipe safety`
8. `fix: add CODECOV_TOKEN to coverage upload`
9. `fix: reference workflow environment for CODECOV_TOKEN`
10. `docs: add Codecov badge setup instructions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Multi-turn conversations with persistent session history via `--session`
  * Capability-based access control for operations (`--capabilities=read,write,exec`)
  * Sandbox directory restrictions for file operations via `--sandbox`

* **Documentation**
  * Architecture decisions for session persistence and web search integration
  * Feature coverage tracking and testing guidelines

* **Tests**
  * E2E tests for session management and capability enforcement
  * Expanded unit tests for configuration, command execution, JSON parsing, and logging

* **Chores**
  * CI/CD workflow authentication improvements
  * Contributing guidelines updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->