### PR TITLE
Change first spinner message to 'warming up...' for better UX

### DIFF
--- a/src/tui/tui.h
+++ b/src/tui/tui.h
@@ -608,7 +608,7 @@ inline std::string render_markdown(const std::string& text, bool color) {
 // --- Spinner ---
 
 /** Default spinner messages — shown while waiting for LLM response */
-inline std::vector<const char*> default_messages() { return {"thinking...", "processing...", "analyzing..."}; }
+inline std::vector<const char*> default_messages() { return {"warming up...", "processing...", "analyzing..."}; }
 
 /** BOFH spinner messages — activate with --why-so-serious */
 inline std::vector<const char*> bofh_messages() {


### PR DESCRIPTION
## Changes
- Changed first spinner message from "thinking..." to "warming up..."

## Motivation
When using large models (e.g., 32B parameters), the initial delay is primarily due to:
- Model loading into VRAM
- CUDA initialization  
- Memory allocation

Rather than actual inference/thinking. The "warming up..." message better reflects this cold-start behavior and improves user experience by setting accurate expectations.

## Testing
- Tested with qwen2.5-coder:32b-instruct-q3_K_M (15GB model)
- Verified spinner displays "warming up..." on first prompt
- Subsequent prompts still show "processing..." and "analyzing..."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated spinner loading message text to provide clearer feedback during processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->