### PR TITLE
fix(tui): use warning color for proposals (#129)

### DIFF
--- a/src/annotation/annotation.cpp
+++ b/src/annotation/annotation.cpp
@@ -337,7 +337,7 @@ std::string strip_annotations(const std::string& text) {
     if (end == std::string::npos) {
       break;
     }
-    result.replace(start, end + 8 - start, tui::active_theme().info.ansi() + "[proposed: write " + path + "]" + ThemeStyle::reset());
+    result.replace(start, end + 8 - start, tui::active_theme().warning.ansi() + "[proposed: write " + path + "]" + ThemeStyle::reset());
   }
 
   // strip <str_replace path="...">...</str_replace>
@@ -360,7 +360,8 @@ std::string strip_annotations(const std::string& text) {
     if (end == std::string::npos) {
       break;
     }
-    result.replace(start, end + 14 - start, tui::active_theme().info.ansi() + "[proposed: str_replace " + path + "]" + ThemeStyle::reset());
+    result.replace(start, end + 14 - start,
+                   tui::active_theme().warning.ansi() + "[proposed: str_replace " + path + "]" + ThemeStyle::reset());
   }
 
   // strip <read ...>
@@ -404,7 +405,8 @@ std::string strip_annotations(const std::string& text) {
     }
     std::string tag = result.substr(start, end - start + 2);
     std::string path = attr(tag, "path");
-    result.replace(start, end + 2 - start, tui::active_theme().info.ansi() + "[proposed: add line to " + path + "]" + ThemeStyle::reset());
+    result.replace(start, end + 2 - start,
+                   tui::active_theme().warning.ansi() + "[proposed: add line to " + path + "]" + ThemeStyle::reset());
   }
 
   // strip <delete_line .../>
@@ -420,7 +422,7 @@ std::string strip_annotations(const std::string& text) {
     std::string tag = result.substr(start, end - start + 2);
     std::string path = attr(tag, "path");
     result.replace(start, end + 2 - start,
-                   tui::active_theme().info.ansi() + "[proposed: delete line from " + path + "]" + ThemeStyle::reset());
+                   tui::active_theme().warning.ansi() + "[proposed: delete line from " + path + "]" + ThemeStyle::reset());
   }
 
   return result;

--- a/src/annotation/annotation_test.cpp
+++ b/src/annotation/annotation_test.cpp
@@ -200,8 +200,8 @@ SCENARIO ("stripped annotations contain themed ANSI codes") {
     std::string text = R"(<write file="test.cpp">content</write>)";
     WHEN ("stripped") {
       auto clean = strip_annotations(text);
-      THEN ("output contains info escape and reset") {
-        CHECK (clean.find(tui::active_theme().info.ansi()) != std::string::npos)
+      THEN ("output contains warning escape and reset") {
+        CHECK (clean.find(tui::active_theme().warning.ansi()) != std::string::npos)
           ;
         CHECK (clean.find("\033[0m") != std::string::npos)
           ;
@@ -213,8 +213,8 @@ SCENARIO ("stripped annotations contain themed ANSI codes") {
     std::string text = R"(<str_replace path="x.cpp"><old>a</old><new>b</new></str_replace>)";
     WHEN ("stripped") {
       auto clean = strip_annotations(text);
-      THEN ("output contains info escape") {
-        CHECK (clean.find(tui::active_theme().info.ansi()) != std::string::npos)
+      THEN ("output contains warning escape") {
+        CHECK (clean.find(tui::active_theme().warning.ansi()) != std::string::npos)
           ;
       }
     }
@@ -456,7 +456,7 @@ SCENARIO ("strip_annotations produces exact output for write") {
     std::string text = "before<write file=\"f.cpp\">code</write>after";
     auto clean = strip_annotations(text);
     THEN ("output is exactly the summary with no leftover tag chars") {
-      CHECK (clean == "before" + tui::active_theme().info.ansi() + "[proposed: write f.cpp]\033[0mafter")
+      CHECK (clean == "before" + tui::active_theme().warning.ansi() + "[proposed: write f.cpp]\033[0mafter")
         ;
     }
   }
@@ -467,7 +467,7 @@ SCENARIO ("strip_annotations produces exact output for str_replace") {
     std::string text = "A<str_replace path=\"x.cpp\"><old>a</old><new>b</new></str_replace>B";
     auto clean = strip_annotations(text);
     THEN ("output is exactly the summary") {
-      CHECK (clean == "A" + tui::active_theme().info.ansi() + "[proposed: str_replace x.cpp]\033[0mB")
+      CHECK (clean == "A" + tui::active_theme().warning.ansi() + "[proposed: str_replace x.cpp]\033[0mB")
         ;
     }
   }
@@ -500,7 +500,7 @@ SCENARIO ("strip_annotations produces exact output for add_line") {
     std::string text = "M<add_line path=\"t.txt\" line_number=\"1\" content=\"x\"/>N";
     auto clean = strip_annotations(text);
     THEN ("output is exactly the summary") {
-      CHECK (clean == "M" + tui::active_theme().info.ansi() + "[proposed: add line to t.txt]\033[0mN")
+      CHECK (clean == "M" + tui::active_theme().warning.ansi() + "[proposed: add line to t.txt]\033[0mN")
         ;
     }
   }
@@ -511,7 +511,7 @@ SCENARIO ("strip_annotations produces exact output for delete_line") {
     std::string text = "J<delete_line path=\"d.txt\" content=\"bye\"/>K";
     auto clean = strip_annotations(text);
     THEN ("output is exactly the summary") {
-      CHECK (clean == "J" + tui::active_theme().info.ansi() + "[proposed: delete line from d.txt]\033[0mK")
+      CHECK (clean == "J" + tui::active_theme().warning.ansi() + "[proposed: delete line from d.txt]\033[0mK")
         ;
     }
   }

--- a/src/repl/repl_annotations.cpp
+++ b/src/repl/repl_annotations.cpp
@@ -515,7 +515,7 @@ std::string strip_exec_annotations(const std::string& text) {
     }
     std::string cmd = result.substr(start + open.size(), end - start - open.size());
     result.replace(start, end + close.size() - start,
-                   tui::active_theme().info.ansi() + "[proposed: exec " + cmd + "]" + ThemeStyle::reset());
+                   tui::active_theme().warning.ansi() + "[proposed: exec " + cmd + "]" + ThemeStyle::reset());
   }
   // Strip remaining annotation-like tags so raw XML never reaches the user
   for (const auto& tag : {"<exec>", "</exec>", "<write", "</write>", "<str_replace", "</str_replace>", "<read ", "<search>", "</search>"}) {


### PR DESCRIPTION
Proposals (write, str_replace, exec, add/delete line) now use the **warning** role (yellow) instead of info (cyan). This makes action requests visually distinct from informational annotations.

- `[proposed: write ...]` → yellow (was cyan)
- `[proposed: exec ...]` → yellow (was cyan)  
- `[read ...]` → cyan (unchanged)
- `[search: ...]` → cyan (unchanged)

Closes #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual styling of annotation tags to use warning theme colors instead of info theme colors. This affects proposed write operations, string replacements, line additions, deletions, and exec commands, providing improved visual distinction and better highlighting in the terminal interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rkristelijn/llama-cli/pull/135)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->