### PR TITLE
fix(ci): parallel sanitizer build + timeout 20min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,17 +287,19 @@ jobs:
     needs: [changes, test]
     if: needs.changes.outputs.src == 'true' && needs.changes.outputs.heavy == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - name: Build and test with ASan/UBSan
+      - name: Build with ASan/UBSan
         run: |
           cmake -B build -DENABLE_SANITIZERS=ON
-          cmake --build build
+          cmake --build build --parallel $(nproc)
+      - name: Run sanitized tests
+        run: |
           ./build/test_config
           ./build/test_json
-          ./build/test_repl
           ./build/test_command
-          ./build/test_annotation
           ./build/test_exec
+          ./build/test_annotation
+          ./build/test_repl
           ./build/test_markdown


### PR DESCRIPTION
Sanitizer job was getting cancelled at 15min timeout.

- Add `--parallel $(nproc)` to cmake build (~2x faster)
- Increase timeout from 15 to 20 minutes  
- Reorder tests: smallest first (fail-fast)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline with improved build optimization and test execution efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rkristelijn/llama-cli/pull/141)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->