### PR TITLE
refactor: rename CMMI to maturity (CMMI is inspiration, not claim)

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -113,7 +113,7 @@ Auto-generated overview of all files in this repo.
 - [`docs/adr/adr-118-cognitive-engagement.md`](docs/adr/adr-118-cognitive-engagement.md) — File content has been updated with recommendations for cognitive engagement while using AI-assisted development tools, emphasizing user review and modification of generated outputs, and incorporating anti-patterns to avoid in the UX design.
 - [`docs/adr/adr-119-slop-detection.md`](docs/adr/adr-119-slop-detection.md) — 25 deterministic grep-based patterns in check-slop.sh detect AI-generated code anti-patterns (pass-through wrappers, catch-log-rethrow, AI naming, uniform line length, emoji bullets, em-dash overuse) in git diffs, backed by arxiv research and slop-scan benchmarks.
 - [`docs/adr/adr-120-research-freshness.md`](docs/adr/adr-120-research-freshness.md) — Track last-researched dates per topic in .config/research-dates.env; warn during make lint when any topic exceeds 30 days with a ready-to-use research prompt. Covers slop detection, model guide, security tools, and portability.
-- [`docs/adr/adr-121-cpm-quality-layer.md`](docs/adr/adr-121-cpm-quality-layer.md) — Adopt CPM (Compliance Process Management) as the shared quality layer across all repos, replacing ad-hoc scripts with a universal framework that provides gamified CMMI levels, shared TUI output, and language-agnostic quality gates.
+- [`docs/adr/adr-121-cpm-quality-layer.md`](docs/adr/adr-121-cpm-quality-layer.md) — Adopt CPM (Compliance Process Management) as the shared quality layer across all repos, replacing ad-hoc scripts with a universal framework that provides gamified maturity levels, shared TUI output, and language-agnostic quality gates.
 - [`docs/adr/adr-122-ci-caching-portability.md`](docs/adr/adr-122-ci-caching-portability.md) — The ADR proposal effectively outlines a two-layer caching strategy for CI build caching across multiple providers, including GitHub Actions, GitLab CI, Codeberg/Forgejo, and self-hosted runners, aiming to reduce pipeline time by 40-60%.
 - [`docs/adr/adr-123-accessible-tui-output.md`](docs/adr/adr-123-accessible-tui-output.md) — Ensure all TUI output is accessible — never rely on color alone for status.
 - [`docs/adr/adr-124-responsive-terminal-ui.md`](docs/adr/adr-124-responsive-terminal-ui.md) — Responsive terminal UI with breakpoints, V-model visualization, and accessible status indicators.
@@ -202,8 +202,8 @@ Auto-generated overview of all files in this repo.
 - [`scripts/git/precommit-check.sh`](scripts/git/precommit-check.sh) — precommit-check.sh — Auto-fix formatting + secret scan (smart: skips unchanged file types).
 - [`scripts/git/prepush-check.sh`](scripts/git/prepush-check.sh) — prepush-check.sh — Validate all checks before pushing (smart: skips unchanged file types).
 - [`scripts/lint/check-ci-yaml.sh`](scripts/lint/check-ci-yaml.sh)
-- [`scripts/lint/check-cmmi.sh`](scripts/lint/check-cmmi.sh)
 - [`scripts/lint/check-interactive-input.sh`](scripts/lint/check-interactive-input.sh) — Check for direct std::cin usage in interactive code (ADR-088).
+- [`scripts/lint/check-maturity.sh`](scripts/lint/check-maturity.sh)
 - [`scripts/lint/check-pipeline-coverage.sh`](scripts/lint/check-pipeline-coverage.sh)
 - [`scripts/lint/check-theme.sh`](scripts/lint/check-theme.sh)
 - [`scripts/lint/check-user-facing-strings.sh`](scripts/lint/check-user-facing-strings.sh) — check-user-facing-strings.sh — Find hardcoded user-facing strings (not test/debug)

--- a/Makefile
+++ b/Makefile
@@ -244,8 +244,8 @@ check-traceability: ## Bidirectional traceability check (ADR-095)
 pipeline-coverage: ## Verify all make targets are in CI or denylist
 	@bash lib/cpm/shell/run.sh check-pipeline-coverage bash scripts/lint/check-pipeline-coverage.sh
 
-cmmi: ## CMMI maturity level audit (ADR-048)
-	@bash lib/cpm/shell/run.sh check-cmmi bash scripts/lint/check-cmmi.sh
+maturity: ## Engineering maturity audit (inspired by CMMI) (ADR-048)
+	@bash lib/cpm/shell/run.sh check-maturity bash scripts/lint/check-maturity.sh
 
 smells: ## Detect engineering anti-patterns (fun but real)
 	@bash lib/cpm/shell/run.sh check-smells bash lib/cpm/checks/cpp/check-smells.sh

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/github/license/rkristelijn/llama-cli)](LICENSE)
 [![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/rkristelijn/a190f75bd7e08ea08f9c16f90571213f/raw/tests.json)](https://github.com/rkristelijn/llama-cli/actions/workflows/ci.yml?query=job%3Aunit-test)
 [![Features](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/rkristelijn/a190f75bd7e08ea08f9c16f90571213f/raw/features.json)](https://github.com/rkristelijn/llama-cli/actions/workflows/ci.yml?query=job%3Afeature-coverage)
-[![CMMI](https://img.shields.io/badge/CMMI-Level_3-brightgreen)](docs/adr/adr-048-quality-framework.md)
+[![Maturity](https://img.shields.io/badge/Maturity-Level_3-brightgreen)](docs/adr/adr-048-quality-framework.md)
 [![Inclusivity](https://img.shields.io/badge/Inclusivity-0_failures-brightgreen)](scripts/lint/check-inclusivity.sh)
 [![Licenses](https://img.shields.io/badge/Licenses-4%2F4_permissive-brightgreen)](scripts/lint/check-licenses.sh)
 [![Deps](https://img.shields.io/badge/Dependencies-4-blue)](CMakeLists.txt)

--- a/cpm.toml
+++ b/cpm.toml
@@ -269,8 +269,8 @@ triggers = ["Makefile", ".github/**"]
 severity = "warning"
 
 [[extend]]
-name = "check-cmmi"
-command = "scripts/lint/check-cmmi.sh"
+name = "check-maturity"
+command = "scripts/lint/check-maturity.sh"
 triggers = ["src/**", "scripts/**", "docs/**"]
 severity = "info"
 

--- a/docs/adr/adr-121-cpm-quality-layer.md
+++ b/docs/adr/adr-121-cpm-quality-layer.md
@@ -1,5 +1,5 @@
 ---
-summary: Adopt CPM (Compliance Process Management) as the shared quality layer across all repos, replacing ad-hoc scripts with a universal framework that provides gamified CMMI levels, shared TUI output, and language-agnostic quality gates.
+summary: Adopt CPM (Compliance Process Management) as the shared quality layer across all repos, replacing ad-hoc scripts with a universal framework that provides gamified maturity levels, shared TUI output, and language-agnostic quality gates.
 status: accepted
 ---
 
@@ -23,7 +23,7 @@ Adopt **CPM (Compliance Process Management)** as the shared quality framework fo
 ### What CPM provides (to any repo, any language)
 
 1. **Shared TUI library** — `lib/shell/ui.sh` for consistent output across all scripts
-2. **Quality gates per CMMI level** — progressive checks unlocked as maturity grows
+2. **Quality gates per maturity level** — progressive checks unlocked as maturity grows
 3. **Gamification** — score, level, progression tracking
 4. **Language-agnostic checks** — ADR enforcement, commit conventions, research freshness, slop detection, portability
 5. **Language-specific plugins** — C++ (clang-tidy, cppcheck), TypeScript (biome), Python (ruff), etc.
@@ -48,7 +48,7 @@ repo/
 3. Gradually move generic checks (slop, portability, research-freshness) into cpm
 4. Keep llama-cli-specific checks (C++ complexity, mermaid tests) local
 
-## CMMI Levels (CPM definition)
+## Maturity Levels (inspired by CMMI)
 
 | Level | Name | What you get |
 |-------|------|-------------|
@@ -310,7 +310,7 @@ This maps to cpm's `install-mode = "nix"` — the most reproducible option.
 | Level | Meaning | Blocks build? |
 |-------|---------|---------------|
 | `error` | Must fix, breaks the gate | Yes |
-| `warning` | Should fix, not urgent | Only at CMMI level 4+ |
+| `warning` | Should fix, not urgent | Only at maturity level 4+ |
 | `info` | Informational, no action needed | Never |
 
 Each tool has an adapter that translates tool-specific output:
@@ -627,7 +627,7 @@ Industry-standard phase names mapped to cpm check categories:
 | **Acceptance** | `test.acceptance` | Feature coverage markers, manual gate |
 | **Release** | `release` | Version bump, changelog, no regressions |
 
-### Severity Progression per CMMI Level
+### Severity Progression per Maturity Level
 
 The same check can be a warning at one level and an error at the next. The V-model grows stricter as maturity increases:
 
@@ -795,7 +795,7 @@ The Makefile's role shrinks to: build, run, install, workflow aliases. Everythin
 | Shell scripts for checks, not the binary | Binary doesn't support [[checks]] yet; shell is portable and debuggable |
 | `init.sh` as single source line | One line per script, fallback logic in one place, not 108 copies |
 | `set +o pipefail` around tee in run.sh | grep-based scripts return exit 1 on no match; tee propagates this |
-| Severity warning = non-blocking | Only `error` blocks the build; warnings are informational until CMMI level 4 |
+| Severity warning = non-blocking | Only `error` blocks the build; warnings are informational until maturity level 4 |
 | Delta detection via git diff | No file watcher, no daemon — simple, stateless, works in CI |
 | Timer uses temp files not associative arrays | macOS /bin/bash is 3.2 (no `declare -A`); temp files work everywhere |
 | JUnit XML in `.tmp/reports/` | Single output dir, CI configures artifact upload path once |

--- a/scripts/lint/check-maturity.sh
+++ b/scripts/lint/check-maturity.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
-# check-cmmi.sh — Automated CMMI maturity level audit (ADR-048).
+# check-maturity.sh — Automated maturity maturity level audit (ADR-048).
 #
-# Verifies which CMMI level checks pass and reports the current level.
+# Verifies which maturity level checks pass and reports the current level.
 # A level is achieved when ALL checks at that level (and below) pass.
 #
 # Usage:
-#   bash scripts/lint/check-cmmi.sh
+#   bash scripts/lint/check-maturity.sh
 #   make cmmi
 #
 # @see docs/adr/adr-048-quality-framework.md
@@ -35,10 +35,10 @@ check() {
 }
 
 main() {
-  print_header "CMMI Maturity Audit (ADR-048)"
+  print_header "maturity Maturity Audit (ADR-048)"
   echo ""
 
-  # ── CMMI 0: Essentials ──
+  # ── maturity 0: Essentials ──
   echo "── Level 0: Essentials ──"
   local l0_fail=0
   check 0 "0.1" "Conventional commits (hook exists)" \
@@ -60,7 +60,7 @@ main() {
   [[ $l0_fail -eq 0 ]] && LEVEL_PASS+=(0)
   echo ""
 
-  # ── CMMI 1: Managed ──
+  # ── maturity 1: Managed ──
   echo "── Level 1: Managed ──"
   local l1_fail=0
   check 1 "1.1" "Unit tests exist (≥100 scenarios)" \
@@ -82,7 +82,7 @@ main() {
   [[ $l1_fail -eq 0 && $l0_fail -eq 0 ]] && LEVEL_PASS+=(1)
   echo ""
 
-  # ── CMMI 2: Defined ──
+  # ── maturity 2: Defined ──
   echo "── Level 2: Defined ──"
   local l2_fail=0
   check 2 "2.1" "Coverage ≥ 55%" \
@@ -104,7 +104,7 @@ main() {
   [[ $l2_fail -eq 0 && $l1_fail -eq 0 && $l0_fail -eq 0 ]] && LEVEL_PASS+=(2)
   echo ""
 
-  # ── CMMI 3: Optimizing ──
+  # ── maturity 3: Optimizing ──
   echo "── Level 3: Optimizing ──"
   local l3_fail=0
   check 3 "3.2" "Auto-generated release notes" \
@@ -124,11 +124,11 @@ main() {
   echo ""
   if [[ $max_level -ge 0 ]]; then
     echo "  ╔══════════════════════════════════╗"
-    printf "  ║  CMMI Level: %-2d %-16s ║\n" "$max_level" \
+    printf "  ║  maturity Level: %-2d %-16s ║\n" "$max_level" \
       "$(case $max_level in 0) echo "(Essentials)" ;; 1) echo "(Managed)" ;; 2) echo "(Defined)" ;; 3) echo "(Optimizing)" ;; *) echo "(Unknown)" ;; esac)"
     echo "  ╚══════════════════════════════════╝"
   else
-    echo "  ⚠ CMMI Level 0 not yet achieved"
+    echo "  ⚠ maturity Level 0 not yet achieved"
   fi
   echo ""
   echo "  @see docs/adr/adr-048-quality-framework.md"

--- a/scripts/lint/check-maturity.sh
+++ b/scripts/lint/check-maturity.sh
@@ -22,7 +22,7 @@ FAIL=0
 LEVEL_PASS=(-1) # Track which levels fully pass
 
 check() {
-  local level="$1" id="$2" desc="$3" cmd="$4"
+  local id="$2" desc="$3" cmd="$4"
   if eval "$cmd" >/dev/null 2>&1; then
     printf "  ✓ %s %s\n" "$id" "$desc"
     PASS=$((PASS + 1))
@@ -132,6 +132,7 @@ main() {
   fi
   echo ""
   echo "  @see docs/adr/adr-048-quality-framework.md"
+  return 0
 }
 
 main "$@"


### PR DESCRIPTION
## Changes

- refactor: rename CMMI to maturity (CMMI is inspiration, not claim)

## Testing

- `make check` passes locally
- Heavy checks (coverage, sanitizers) run when draft is removed: `gh pr ready`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed quality audit make target from `cmmi` to `maturity`.
  * Updated project badge and framework documentation to use "maturity levels" instead of "CMMI levels" across all public-facing materials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rkristelijn/llama-cli/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->